### PR TITLE
Fix: update backend.hanna.co.zw SSL certificate path in nginx

### DIFF
--- a/nginx_proxy/nginx.conf
+++ b/nginx_proxy/nginx.conf
@@ -74,8 +74,8 @@ server {
     server_name backend.hanna.co.zw;
  
     # SSL certificate path for your backend domain
-    ssl_certificate /etc/letsencrypt/live/dashboard.hanna.co.zw-0001/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/dashboard.hanna.co.zw-0001/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/backend.hanna.co.zw/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/backend.hanna.co.zw/privkey.pem;
 
     # Recommended SSL settings
     include /etc/nginx/ssl_custom/options-ssl-nginx.conf;


### PR DESCRIPTION
Switch the backend server block in `nginx_proxy/nginx.conf` from the shared `dashboard.hanna.co.zw-0001` certificate to the dedicated `backend.hanna.co.zw` certificate renewed via certbot standalone (expires 2026-09-07).

```diff
- ssl_certificate     /etc/letsencrypt/live/dashboard.hanna.co.zw-0001/fullchain.pem;
- ssl_certificate_key /etc/letsencrypt/live/dashboard.hanna.co.zw-0001/privkey.pem;
+ ssl_certificate     /etc/letsencrypt/live/backend.hanna.co.zw/fullchain.pem;
+ ssl_certificate_key /etc/letsencrypt/live/backend.hanna.co.zw/privkey.pem;
```

After pulling, reload nginx on the server:
```bash
docker compose exec nginx nginx -t
docker compose exec nginx nginx -s reload
```

https://claude.ai/code/session_018BAdMYnxaofogGdLcftb9j

---
_Generated by [Claude Code](https://claude.ai/code/session_018BAdMYnxaofogGdLcftb9j)_