### PR TITLE
Fix nginx SSL: mount host /etc/letsencrypt instead of Docker volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -211,7 +211,7 @@ services:
     volumes:
       - ./nginx_proxy/nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - mediafiles_volume:/srv/www/media:ro  # Mount media files (read-only, Django serves them)
-      - npm_letsencrypt:/etc/letsencrypt:ro  # SSL certificates (read-only)
+      - /etc/letsencrypt:/etc/letsencrypt:ro  # SSL certificates from host (read-only)
       - ./nginx_proxy/ssl_custom:/etc/nginx/ssl_custom:ro  # Custom SSL configs
       - letsencrypt_webroot:/var/www/letsencrypt  # ACME challenge directory for Let's Encrypt (read-write needed)
     depends_on:
@@ -224,7 +224,7 @@ services:
     image: certbot/certbot:latest
     container_name: whatsappcrm_certbot
     volumes:
-      - npm_letsencrypt:/etc/letsencrypt
+      - /etc/letsencrypt:/etc/letsencrypt  # SSL certificates from host
       - letsencrypt_webroot:/var/www/letsencrypt
       - ./certbot-renew.sh:/usr/local/bin/certbot-renew.sh:ro
     entrypoint: /bin/sh /usr/local/bin/certbot-renew.sh


### PR DESCRIPTION
## Problem
The nginx container was mounting the `npm_letsencrypt` Docker volume at `/etc/letsencrypt`. However, certbot run directly on the host (via `--standalone`) writes certificates to the **host filesystem** `/etc/letsencrypt` — a completely separate location from the Docker volume. This caused:
```
[emerg] cannot load certificate "/etc/letsencrypt/live/backend.hanna.co.zw/fullchain.pem": No such file or directory
```

## Fix
Switch both `nginx` and `certbot` services from the Docker volume to a **host bind mount**:
```diff
- npm_letsencrypt:/etc/letsencrypt:ro
+ /etc/letsencrypt:/etc/letsencrypt:ro
```
Now any cert issued or renewed on the host via standalone certbot is immediately visible inside the containers — no manual copy steps needed.

## After pulling on server
```bash
git pull
docker compose up -d --force-recreate nginx
```

https://claude.ai/code/session_018BAdMYnxaofogGdLcftb9j

---
_Generated by [Claude Code](https://claude.ai/code/session_018BAdMYnxaofogGdLcftb9j)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose SSL certificate configuration for nginx and certbot services, transitioning from named volume mounts to direct host directory bind mounts (`/etc/letsencrypt`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->