### PR TITLE
Fix nginx SSL: point dashboard and hanna.co.zw blocks at host cert paths

### DIFF
--- a/nginx_proxy/nginx.conf
+++ b/nginx_proxy/nginx.conf
@@ -33,8 +33,8 @@ server {
     server_name dashboard.hanna.co.zw;
 
     # SSL certificate path for your frontend domain
-    ssl_certificate /etc/letsencrypt/live/dashboard.hanna.co.zw-0001/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/dashboard.hanna.co.zw-0001/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/dashboard.hanna.co.zw/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/dashboard.hanna.co.zw/privkey.pem;
 
     # Recommended SSL settings
     include /etc/nginx/ssl_custom/options-ssl-nginx.conf;
@@ -137,8 +137,8 @@ server {
     server_name hanna.co.zw;
 
     # SSL certificate path for your domain
-    ssl_certificate /etc/letsencrypt/live/dashboard.hanna.co.zw-0001/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/dashboard.hanna.co.zw-0001/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/hanna.co.zw/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/hanna.co.zw/privkey.pem;
 
     # Recommended SSL settings
     include /etc/nginx/ssl_custom/options-ssl-nginx.conf;


### PR DESCRIPTION
## Problem
After switching to the host `/etc/letsencrypt` bind mount (#340), the backend cert loads fine — but the `dashboard.hanna.co.zw` and `hanna.co.zw` server blocks still pointed at `dashboard.hanna.co.zw-0001`, which only existed in the old `npm_letsencrypt` Docker volume:

```
[emerg] cannot load certificate "/etc/letsencrypt/live/dashboard.hanna.co.zw-0001/fullchain.pem": No such file or directory
```

## Fix
Point each server block at its own standard host cert path:
- `dashboard.hanna.co.zw` block → `/etc/letsencrypt/live/dashboard.hanna.co.zw/`
- `hanna.co.zw` block → `/etc/letsencrypt/live/hanna.co.zw/`

## Required on server BEFORE recreating nginx
If these certs don't exist on the host yet (`sudo ls /etc/letsencrypt/live/`), issue them while nginx is down:
```bash
sudo certbot certonly --standalone -d dashboard.hanna.co.zw
sudo certbot certonly --standalone -d hanna.co.zw
```
Then:
```bash
git pull
docker compose up -d --force-recreate nginx
```

https://claude.ai/code/session_018BAdMYnxaofogGdLcftb9j

---
_Generated by [Claude Code](https://claude.ai/code/session_018BAdMYnxaofogGdLcftb9j)_