### PR TITLE
Add published flag to gate product display on shop

### DIFF
--- a/hanna-management-frontend/app/client/(protected)/shop/page.tsx
+++ b/hanna-management-frontend/app/client/(protected)/shop/page.tsx
@@ -16,6 +16,7 @@ interface Product {
   price: string;
   currency: string;
   is_active: boolean;
+  published: boolean;
   stock_quantity: number;
   product_type: string;
   category: {
@@ -217,8 +218,9 @@ export default function ShopPage() {
       }
       
       console.log('Total products fetched:', allProducts.length);
-      const activeProducts = allProducts.filter((p: Product) => p.is_active);
-      console.log('Active products:', activeProducts.length);
+      // Only show products that are active and published to the shop
+      const activeProducts = allProducts.filter((p: Product) => p.is_active && p.published);
+      console.log('Active & published products:', activeProducts.length);
       setProducts(activeProducts);
       setLoading(false);
     } catch (err) {

--- a/hanna-management-frontend/app/shop/_components/CategoryShopLayout.tsx
+++ b/hanna-management-frontend/app/shop/_components/CategoryShopLayout.tsx
@@ -182,11 +182,11 @@ export default function CategoryShopLayout({ config }: CategoryShopLayoutProps) 
         const res: any = await apiClient.get(next);
         all = [...all, ...normalizePaginatedResponse<Product>(res.data)];
         next = res.data.next ? res.data.next.replace(/^https?:\/\/[^/]+/, '') : null;
-        setAllProducts(all.filter((p) => p.is_active));
+        setAllProducts(all.filter((p) => p.is_active && p.published));
         if (firstPage) { setLoading(false); firstPage = false; }
       }
       try {
-        sessionStorage.setItem(PRODUCTS_CACHE_KEY, JSON.stringify(all.filter((p) => p.is_active)));
+        sessionStorage.setItem(PRODUCTS_CACHE_KEY, JSON.stringify(all.filter((p) => p.is_active && p.published)));
       } catch { /* best-effort */ }
     } catch {
       setAllProducts((prev) => {

--- a/hanna-management-frontend/app/shop/_components/ProductCard.tsx
+++ b/hanna-management-frontend/app/shop/_components/ProductCard.tsx
@@ -11,6 +11,7 @@ export interface Product {
   price: string;
   currency: string;
   is_active: boolean;
+  published: boolean;
   stock_quantity: number;
   product_type: string;
   featured?: boolean;

--- a/hanna-management-frontend/app/shop/page.tsx
+++ b/hanna-management-frontend/app/shop/page.tsx
@@ -102,12 +102,12 @@ export default function PublicShopPage() {
         const res: any = await apiClient.get(next);
         all = [...all, ...normalizePaginatedResponse<Product>(res.data)];
         next = res.data.next ? res.data.next.replace(/^https?:\/\/[^/]+/, '') : null;
-        const active = all.filter((p) => p.is_active);
+        const active = all.filter((p) => p.is_active && p.published);
         setProducts(active);
         if (firstPage) { setLoading(false); firstPage = false; }
       }
       try {
-        sessionStorage.setItem(PRODUCTS_CACHE_KEY, JSON.stringify(all.filter((p) => p.is_active)));
+        sessionStorage.setItem(PRODUCTS_CACHE_KEY, JSON.stringify(all.filter((p) => p.is_active && p.published)));
       } catch { /* best-effort */ }
     } catch {
       setProducts((prev) => {

--- a/whatsappcrm_backend/products_and_services/admin.py
+++ b/whatsappcrm_backend/products_and_services/admin.py
@@ -118,19 +118,20 @@ class ProductAdmin(admin.ModelAdmin):
     """
     Admin interface for the Product model.
     """
-    list_display = ('name', 'sku', 'barcode', 'product_type', 'category', 'price', 'is_active', 'stock_quantity', 'meta_sync_status', 'country_of_origin', 'brand', 'zoho_item_id')
+    list_display = ('name', 'sku', 'barcode', 'product_type', 'category', 'price', 'is_active', 'published', 'stock_quantity', 'meta_sync_status', 'country_of_origin', 'brand', 'zoho_item_id')
+    list_editable = ('published',)
     search_fields = ('name', 'sku', 'barcode', 'description', 'brand', 'zoho_item_id')
-    list_filter = ('product_type', 'category', 'is_active', 'country_of_origin', 'brand')
+    list_filter = ('product_type', 'category', 'is_active', 'published', 'country_of_origin', 'brand')
+    actions = ['reset_meta_sync_attempts', 'sync_to_meta_catalog', 'set_meta_visibility_published', 'set_meta_visibility_hidden', 'sync_selected_items', 'publish_to_shop', 'unpublish_from_shop']
     ordering = ('name',)
     inlines = [ProductImageInline]
-    actions = ['reset_meta_sync_attempts', 'sync_to_meta_catalog', 'set_meta_visibility_published', 'set_meta_visibility_hidden', 'sync_selected_items']
-    
+
     fieldsets = (
         (None, {
             'fields': ('name', 'sku', 'barcode', 'description', 'product_type', 'category', 'brand')
         }),
         ('Pricing & Availability', {
-            'fields': ('price', 'currency', 'is_active')
+            'fields': ('price', 'currency', 'is_active', 'published')
         }),
         ('Inventory & Origin', {
             'fields': ('stock_quantity', 'country_of_origin')
@@ -196,6 +197,26 @@ class ProductAdmin(admin.ModelAdmin):
         self.message_user(
             request,
             f'Reset sync attempts for {count} product(s). They will be synced on next save.'
+        )
+
+    @admin.action(description='Publish selected products to shop')
+    def publish_to_shop(self, request, queryset):
+        """Mark selected products as published so they appear on the shop."""
+        count = queryset.update(published=True)
+        self.message_user(
+            request,
+            f'{count} product(s) published to the shop.',
+            messages.SUCCESS
+        )
+
+    @admin.action(description='Unpublish selected products from shop')
+    def unpublish_from_shop(self, request, queryset):
+        """Mark selected products as unpublished so they are hidden from the shop."""
+        count = queryset.update(published=False)
+        self.message_user(
+            request,
+            f'{count} product(s) unpublished from the shop.',
+            messages.SUCCESS
         )
 
     @admin.action(description='Sync selected products to Meta Catalog')

--- a/whatsappcrm_backend/products_and_services/models.py
+++ b/whatsappcrm_backend/products_and_services/models.py
@@ -61,6 +61,7 @@ class Product(models.Model):
     price = models.DecimalField(_("Price"), max_digits=12, decimal_places=2, null=True, blank=True)
     currency = models.CharField(_("Currency"), max_length=3, default='USD')
     is_active = models.BooleanField(_("Is Active"), default=True, help_text=_("Whether this item is available for sale."))
+    published = models.BooleanField(_("Published"), default=False, db_index=True, help_text=_("Tick to display this product on the shop. Unpublished products are hidden from the storefront."))
     website_url = models.URLField(_("Website URL"), blank=True, null=True)
     whatsapp_catalog_id = models.CharField(_("WhatsApp Catalog ID"), max_length=255, blank=True, null=True)
     country_of_origin = models.CharField(_("Country of Origin"), max_length=2, blank=True, null=True, help_text=_("The two-letter country code (e.g., US, GB) required by WhatsApp."))

--- a/whatsappcrm_backend/products_and_services/views.py
+++ b/whatsappcrm_backend/products_and_services/views.py
@@ -60,20 +60,25 @@ class ProductViewSet(viewsets.ModelViewSet):
         - is_active: Filter by active status (default: True for public list)
         """
         queryset = Product.objects.prefetch_related('images').all()
-        
-        # For public list view, only show active products by default
+
+        # For public list view, only show active, published products by default
         if self.action == 'list' and not self.request.user.is_authenticated:
-            queryset = queryset.filter(is_active=True)
-        
+            queryset = queryset.filter(is_active=True, published=True)
+
         # Allow filtering by category
         category_id = self.request.query_params.get('category_id')
         if category_id:
             queryset = queryset.filter(category_id=category_id)
-        
+
         # Allow filtering by is_active
         is_active = self.request.query_params.get('is_active')
         if is_active is not None:
             queryset = queryset.filter(is_active=is_active.lower() == 'true')
+
+        # Allow filtering by published (shop visibility)
+        published = self.request.query_params.get('published')
+        if published is not None:
+            queryset = queryset.filter(published=published.lower() == 'true')
 
         # Allow filtering by featured
         featured = self.request.query_params.get('featured')


### PR DESCRIPTION
## Summary

Adds a **Published** flag to products. A product must be published (ticked) for it to appear on the shop/storefront. Unpublished products stay hidden even if they're active.

## Changes

**Backend (`products_and_services`)**
- New `published` BooleanField on `Product` (default `False`, indexed). Exposed automatically via the `ProductSerializer` (`fields = '__all__'`).
- `ProductViewSet.get_queryset`: anonymous storefront listings now require `is_active=True` **and** `published=True`; added a `?published=true|false` query param.
- Django admin: `published` shown in the list view with inline editing, added to list filters and the "Pricing & Availability" fieldset, plus new bulk **Publish/Unpublish to shop** actions.

**Frontend (storefront + client shop)**
- Added `published` to the shared `Product` type.
- Public storefront (`app/shop`) and client shop (`app/client/.../shop`) now only render products that are both active and published.

## Migration note
Database migrations are generated at deploy time (`makemigrations`), so no migration file is committed. Because the field defaults to `False`, **existing products will be unpublished after deploy** — publish them via the new admin bulk action or the inline checkbox so they reappear on the shop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTPbndSgYZnJWsNZnHfHf7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Published" status for products, allowing admins to control shop visibility independently from product status.
  * Admins can now bulk publish/unpublish products through the admin interface.

* **Bug Fixes**
  * Shop now displays only products that are both active and published, ensuring consistent product visibility across storefront pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->