### PR TITLE
Add PWA functionality to the management/storefront app

### DIFF
--- a/hanna-management-frontend/app/components/ServiceWorkerRegistration.tsx
+++ b/hanna-management-frontend/app/components/ServiceWorkerRegistration.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Registers the PWA service worker on the client.
+ * Registration is skipped in development to avoid stale caches while iterating.
+ */
+export default function ServiceWorkerRegistration() {
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (!('serviceWorker' in navigator)) return;
+    if (process.env.NODE_ENV !== 'production') return;
+
+    const register = () => {
+      navigator.serviceWorker
+        .register('/sw.js', { scope: '/' })
+        .catch((err) => {
+          // Non-fatal: the app still works without offline support.
+          console.warn('[pwa] Service worker registration failed:', err);
+        });
+    };
+
+    if (document.readyState === 'complete') {
+      register();
+    } else {
+      window.addEventListener('load', register);
+      return () => window.removeEventListener('load', register);
+    }
+  }, []);
+
+  return null;
+}

--- a/hanna-management-frontend/app/layout.tsx
+++ b/hanna-management-frontend/app/layout.tsx
@@ -1,6 +1,7 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { Providers } from "./providers";
+import ServiceWorkerRegistration from "./components/ServiceWorkerRegistration";
 
 export const metadata: Metadata = {
   title: {
@@ -8,10 +9,21 @@ export const metadata: Metadata = {
     template: "%s | Hanna"
   },
   description: "Comprehensive management system for solar installations, warranties, products, and customer service in Zimbabwe",
+  applicationName: "Hanna",
   keywords: ["solar", "warranty management", "installation tracking", "Zimbabwe", "CRM", "inventory management"],
   authors: [{ name: "Hanna Digital" }],
   creator: "Hanna Digital",
   publisher: "Hanna Digital",
+  manifest: "/manifest.webmanifest",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "default",
+    title: "Hanna",
+  },
+  icons: {
+    icon: "/icons/icon.svg",
+    apple: "/icons/icon.svg",
+  },
   formatDetection: {
     telephone: false,
   },
@@ -25,6 +37,13 @@ export const metadata: Metadata = {
   },
 };
 
+export const viewport: Viewport = {
+  themeColor: "#4f46e5",
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -34,6 +53,7 @@ export default function RootLayout({
     <html lang="en">
       <body className="antialiased font-sans">
         <Providers>{children}</Providers>
+        <ServiceWorkerRegistration />
       </body>
     </html>
   );

--- a/hanna-management-frontend/app/manifest.ts
+++ b/hanna-management-frontend/app/manifest.ts
@@ -1,0 +1,46 @@
+import type { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'Hanna Management System',
+    short_name: 'Hanna',
+    description:
+      'Comprehensive management system for solar installations, warranties, products, and customer service in Zimbabwe',
+    start_url: '/',
+    scope: '/',
+    display: 'standalone',
+    orientation: 'portrait',
+    background_color: '#ffffff',
+    theme_color: '#4f46e5',
+    lang: 'en-ZW',
+    categories: ['business', 'shopping', 'productivity'],
+    icons: [
+      {
+        src: '/icons/icon.svg',
+        sizes: 'any',
+        type: 'image/svg+xml',
+        purpose: 'any',
+      },
+      {
+        src: '/icons/icon-maskable.svg',
+        sizes: 'any',
+        type: 'image/svg+xml',
+        purpose: 'maskable',
+      },
+    ],
+    shortcuts: [
+      {
+        name: 'Shop',
+        short_name: 'Shop',
+        description: 'Browse and purchase solar products',
+        url: '/shop',
+      },
+      {
+        name: 'My Dashboard',
+        short_name: 'Dashboard',
+        description: 'Your personal dashboard',
+        url: '/client/dashboard',
+      },
+    ],
+  };
+}

--- a/hanna-management-frontend/public/icons/icon-maskable.svg
+++ b/hanna-management-frontend/public/icons/icon-maskable.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="Hanna">
+  <defs>
+    <linearGradient id="bgm" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4f46e5"/>
+      <stop offset="1" stop-color="#7c3aed"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#bgm)"/>
+  <g transform="translate(256 256) scale(0.66) translate(-256 -256)">
+    <g fill="none" stroke="#fde68a" stroke-width="22" stroke-linecap="round">
+      <line x1="256" y1="92" x2="256" y2="138"/>
+      <line x1="256" y1="374" x2="256" y2="420"/>
+      <line x1="92" y1="256" x2="138" y2="256"/>
+      <line x1="374" y1="256" x2="420" y2="256"/>
+      <line x1="140" y1="140" x2="172" y2="172"/>
+      <line x1="340" y1="340" x2="372" y2="372"/>
+      <line x1="372" y1="140" x2="340" y2="172"/>
+      <line x1="172" y1="340" x2="140" y2="372"/>
+    </g>
+    <circle cx="256" cy="256" r="78" fill="#fcd34d"/>
+    <text x="256" y="284" font-family="Arial, Helvetica, sans-serif" font-size="92" font-weight="700" fill="#4f46e5" text-anchor="middle">H</text>
+  </g>
+</svg>

--- a/hanna-management-frontend/public/icons/icon.svg
+++ b/hanna-management-frontend/public/icons/icon.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512" role="img" aria-label="Hanna">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#4f46e5"/>
+      <stop offset="1" stop-color="#7c3aed"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#bg)"/>
+  <g fill="none" stroke="#fde68a" stroke-width="22" stroke-linecap="round">
+    <line x1="256" y1="92" x2="256" y2="138"/>
+    <line x1="256" y1="374" x2="256" y2="420"/>
+    <line x1="92" y1="256" x2="138" y2="256"/>
+    <line x1="374" y1="256" x2="420" y2="256"/>
+    <line x1="140" y1="140" x2="172" y2="172"/>
+    <line x1="340" y1="340" x2="372" y2="372"/>
+    <line x1="372" y1="140" x2="340" y2="172"/>
+    <line x1="172" y1="340" x2="140" y2="372"/>
+  </g>
+  <circle cx="256" cy="256" r="78" fill="#fcd34d"/>
+  <text x="256" y="284" font-family="Arial, Helvetica, sans-serif" font-size="92" font-weight="700" fill="#4f46e5" text-anchor="middle">H</text>
+</svg>

--- a/hanna-management-frontend/public/offline.html
+++ b/hanna-management-frontend/public/offline.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Offline | Hanna</title>
+  <style>
+    :root { color-scheme: light; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
+      background: linear-gradient(135deg, #eef2ff, #faf5ff);
+      color: #1f2937;
+      padding: 24px;
+    }
+    .card {
+      max-width: 420px;
+      width: 100%;
+      text-align: center;
+      background: #fff;
+      border-radius: 20px;
+      padding: 40px 28px;
+      box-shadow: 0 20px 45px rgba(79, 70, 229, 0.15);
+    }
+    .badge {
+      width: 72px; height: 72px;
+      margin: 0 auto 20px;
+      border-radius: 18px;
+      background: linear-gradient(135deg, #4f46e5, #7c3aed);
+      display: flex; align-items: center; justify-content: center;
+      color: #fcd34d; font-size: 34px; font-weight: 700;
+    }
+    h1 { font-size: 22px; margin: 0 0 8px; }
+    p { color: #6b7280; line-height: 1.5; margin: 0 0 24px; }
+    button {
+      border: 0; cursor: pointer;
+      background: #4f46e5; color: #fff;
+      font-size: 15px; font-weight: 600;
+      padding: 12px 22px; border-radius: 10px;
+    }
+    button:hover { background: #4338ca; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="badge">H</div>
+    <h1>You're offline</h1>
+    <p>We can't reach the Hanna servers right now. Check your connection and try again — any pages you've already visited remain available.</p>
+    <button onclick="window.location.reload()">Try again</button>
+  </div>
+</body>
+</html>

--- a/hanna-management-frontend/public/sw.js
+++ b/hanna-management-frontend/public/sw.js
@@ -1,0 +1,84 @@
+/*
+ * Hanna PWA service worker.
+ * - App-shell style offline support with a versioned cache.
+ * - Navigation requests: network-first, falling back to cache then /offline.
+ * - Static assets (same-origin GET): stale-while-revalidate.
+ * - API, auth and cross-origin requests are never cached.
+ */
+const CACHE_VERSION = 'v1';
+const CACHE_NAME = `hanna-cache-${CACHE_VERSION}`;
+const OFFLINE_URL = '/offline.html';
+
+const PRECACHE_URLS = [OFFLINE_URL, '/icons/icon.svg'];
+
+// Paths that must always hit the network (never served from cache).
+const NETWORK_ONLY_PREFIXES = ['/crm-api', '/api', '/auth'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+function isNetworkOnly(url) {
+  return NETWORK_ONLY_PREFIXES.some((prefix) => url.pathname.startsWith(prefix));
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  // Only handle same-origin GET requests; let everything else pass through.
+  if (request.method !== 'GET') return;
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+  if (isNetworkOnly(url)) return;
+
+  // Navigations: network-first with offline fallback.
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      (async () => {
+        try {
+          const networkResponse = await fetch(request);
+          const cache = await caches.open(CACHE_NAME);
+          cache.put(request, networkResponse.clone());
+          return networkResponse;
+        } catch {
+          const cached = await caches.match(request);
+          return cached || (await caches.match(OFFLINE_URL));
+        }
+      })()
+    );
+    return;
+  }
+
+  // Static assets: stale-while-revalidate.
+  event.respondWith(
+    (async () => {
+      const cache = await caches.open(CACHE_NAME);
+      const cached = await cache.match(request);
+      const networkFetch = fetch(request)
+        .then((response) => {
+          if (response && response.status === 200 && response.type === 'basic') {
+            cache.put(request, response.clone());
+          }
+          return response;
+        })
+        .catch(() => cached);
+      return cached || networkFetch;
+    })()
+  );
+});


### PR DESCRIPTION
## Summary

Makes the customer-facing Next.js app (`hanna-management-frontend`) an installable, offline-capable **Progressive Web App**. Implemented natively (no `next-pwa` dependency, which isn't reliable on Next 16 / Turbopack).

## What's included

- **`app/manifest.ts`** — web app manifest served at `/manifest.webmanifest`: name, short name, theme/background colors, `standalone` display, icons, and app shortcuts (Shop, Dashboard).
- **`public/icons/`** — branded SVG app icon plus a `maskable` variant (safe-zone padded). SVG icons with `sizes: "any"` satisfy install requirements on modern browsers.
- **`public/sw.js`** — service worker:
  - Navigations → network-first, falling back to cache then a branded offline page.
  - Static assets → stale-while-revalidate with a versioned cache.
  - **API/auth and cross-origin requests are never cached** (`/crm-api`, `/api`, `/auth`).
- **`public/offline.html`** — branded offline fallback page with a retry button.
- **`ServiceWorkerRegistration`** client component, mounted in the root layout. Registers `/sw.js` **in production only** to avoid stale caches during development.
- **Root layout** — `manifest` link, `theme-color` via the `viewport` export, and Apple web-app meta for iOS standalone installs.

## Notes / follow-ups
- Icons are SVG for crispness and zero binary assets. If you want raster `192x192` / `512x512` PNGs (e.g. for older Android splash screens), that can be added later.
- The service worker is intentionally conservative: it won't interfere with authenticated API traffic.

## Testing
- SVG, service-worker JS, and offline HTML validated as well-formed. A full `next build` wasn't run here because the container has no `node_modules`; recommend verifying install + Lighthouse PWA audit in CI/preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTPbndSgYZnJWsNZnHfHf7)_