### PR TITLE
Fix SynchronousOnlyOperation in gevent Celery workers (bot silent)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,13 @@ services:
       -P gevent
       --concurrency=20
       --prefetch-multiplier=1
+    # Under the gevent pool, gevent monkey-patching + async_to_sync (Channels)
+    # makes Django's async-safety guard fire a false SynchronousOnlyOperation on
+    # ORM calls. There is no real async web context in a Celery worker, so it is
+    # safe to disable the guard here. Without this, ORM access in tasks (and the
+    # result backend) fails and messages are never sent.
+    environment:
+      DJANGO_ALLOW_ASYNC_UNSAFE: "true"
     volumes:
       - ./whatsappcrm_backend:/app
       - mediafiles_volume:/app/mediafiles
@@ -110,6 +117,9 @@ services:
       -P gevent
       --concurrency=10
       --prefetch-multiplier=1
+    # See celery_messaging_worker: gevent pool needs the async guard disabled.
+    environment:
+      DJANGO_ALLOW_ASYNC_UNSAFE: "true"
     volumes:
       - ./whatsappcrm_backend:/app
       - mediafiles_volume:/app/mediafiles


### PR DESCRIPTION
## Summary

Fixes the `django.core.exceptions.SynchronousOnlyOperation` traceback that started after the queue-routing fix, which is why the bot still wasn't replying:

```
SynchronousOnlyOperation: You cannot call this from an async context
- use a thread or sync_to_async.
...
File ".../celery/fixups/django.py", line 230, in _close_database
    conn.close()
```

It blew up in two places per task: inside `send_whatsapp_message_task` (ORM access) and right after — in `django_celery_results`' result-backend write (`store_result`) and in Celery's Django fixup `close_database`.

## Why it happens

Under the **gevent pool** (`-P gevent`), `gevent.monkey.patch_all()` plus any `async_to_sync` / Channels code path leaves Django's `async_unsafe` guard convinced an asyncio event loop is running. Once that's the case, **every ORM call inside the worker raises `SynchronousOnlyOperation`**. Outgoing sends fail, results can't be stored, and the bot goes silent.

## Fix

Set `DJANGO_ALLOW_ASYNC_UNSAFE=true` on the two gevent workers (`celery_messaging_worker`, `celery_flow_worker`) in `docker-compose.yml`. There's no real async web context inside a Celery worker, so disabling the guard is safe — this is the documented mitigation for the Django + gevent + Celery combination. The web/ASGI process keeps the guard intact.

## Test plan

- [ ] `docker compose up -d --force-recreate celery_messaging_worker celery_flow_worker`
- [ ] Send a WhatsApp message → bot replies; no `SynchronousOnlyOperation` in `docker compose logs celery_messaging_worker celery_flow_worker`
- [ ] Confirm `django_celery_results_taskresult` rows are being written

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTPbndSgYZnJWsNZnHfHf7)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for background task workers to support asynchronous operations more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->