### PR TITLE
Stop Celery "missed heartbeat" log noise on Redis broker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,9 @@ services:
       -P gevent
       --concurrency=20
       --prefetch-multiplier=1
+      --without-gossip
+      --without-mingle
+      --without-heartbeat
     # Under the gevent pool, gevent monkey-patching + async_to_sync (Channels)
     # makes Django's async-safety guard fire a false SynchronousOnlyOperation on
     # ORM calls. There is no real async web context in a Celery worker, so it is
@@ -117,6 +120,9 @@ services:
       -P gevent
       --concurrency=10
       --prefetch-multiplier=1
+      --without-gossip
+      --without-mingle
+      --without-heartbeat
     # See celery_messaging_worker: gevent pool needs the async guard disabled.
     environment:
       DJANGO_ALLOW_ASYNC_UNSAFE: "true"
@@ -140,6 +146,9 @@ services:
       -Q cpu_heavy
       -l INFO
       --concurrency=2
+      --without-gossip
+      --without-mingle
+      --without-heartbeat
     volumes:
       - ./whatsappcrm_backend:/app
       - staticfiles_volume:/app/staticfiles

--- a/whatsappcrm_backend/whatsappcrm_backend/settings.py
+++ b/whatsappcrm_backend/whatsappcrm_backend/settings.py
@@ -377,13 +377,13 @@ CELERY_TASK_ACKS_LATE = True
 # Reject tasks on worker lost (requeue them to be picked up by another worker)
 CELERY_TASK_REJECT_ON_WORKER_LOST = True
 
-# Broker heartbeat: how often (seconds) the worker checks its Redis connection
-# is alive. The gevent pool's cooperative scheduling means a worker busy
-# running a greenlet can briefly delay the heartbeat check, which is what
-# produces benign "missed heartbeat" gossip log lines between workers. A
-# slightly longer heartbeat interval plus retry-on-startup avoids workers
-# flapping on transient delays without masking a real broker outage.
-CELERY_BROKER_HEARTBEAT = int(os.getenv('CELERY_BROKER_HEARTBEAT', '30'))
+# Keep broker reconnects resilient. socket_keepalive lets the OS detect a
+# dropped Redis TCP connection promptly instead of hanging on a dead socket.
+# (Note: AMQP broker_heartbeat does NOT apply to the Redis transport, so the
+# "missed heartbeat" gossip lines are handled at the worker level instead —
+# the workers run with --without-gossip/--without-mingle/--without-heartbeat
+# in docker-compose.yml, since those inter-worker clustering features are
+# RabbitMQ-oriented and only add overhead/noise on a single-broker Redis setup.)
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_BROKER_TRANSPORT_OPTIONS = {
     'socket_keepalive': True,


### PR DESCRIPTION
## Summary

Eliminates the `missed heartbeat from celery@...` INFO log lines that persisted after the earlier broker tweak.

## Root cause

Those lines come from Celery's **inter-worker gossip protocol** — peer workers monitoring each other's heartbeats — not from a worker crashing. The features behind it (`gossip`, `mingle`, worker `heartbeat`) are RabbitMQ-cluster oriented. On a single-broker **Redis** deployment they only add broker overhead, and a busy gevent worker that's a beat late broadcasting its heartbeat triggers the "missed heartbeat" message even though nothing is actually wrong.

The previously added `CELERY_BROKER_HEARTBEAT` was an **AMQP-only** setting and is silently ignored by the Redis transport, which is why the messages continued.

## Changes

- Run all three workers with `--without-gossip --without-mingle --without-heartbeat` (`docker-compose.yml`).
- Remove the inert `CELERY_BROKER_HEARTBEAT` setting; keep `socket_keepalive` + connection-retry-on-startup for resilient Redis reconnects (`settings.py`).

## Validation

- `settings.py` parses; `docker-compose.yml` is valid YAML.

## Deploy note

Requires recreating the Celery worker containers (`docker compose up -d --force-recreate celery_messaging_worker celery_flow_worker celery_cpu_worker`) for the new worker flags to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTPbndSgYZnJWsNZnHfHf7)_