### PR TITLE
Fix Paynow payment confirmation and shop checkout integrity bugs

### DIFF
--- a/hanna-management-frontend/app/shop/checkout/page.tsx
+++ b/hanna-management-frontend/app/shop/checkout/page.tsx
@@ -285,11 +285,16 @@ export default function CheckoutPage() {
       return;
     }
 
+    // Guards state updates from an in-flight request that resolves after this
+    // effect has been cleaned up (unmount, step change, or reference change),
+    // which would otherwise call setState on a stale/unmounted run.
+    let active = true;
     setPaymentPollStatus('pending');
 
     const checkStatus = async () => {
       try {
         const res = await apiClient.get(`/crm-api/paynow/payment-status/${paymentInfo.payment_reference}/`);
+        if (!active) return;
         const s = res.data?.status;
         if (s === 'paid') {
           setPaymentPollStatus('paid');
@@ -308,13 +313,18 @@ export default function CheckoutPage() {
     checkStatus();
     pollIntervalRef.current = setInterval(checkStatus, PAYMENT_POLL_INTERVAL_MS);
     pollTimeoutRef.current = setTimeout(() => {
-      setPaymentPollStatus((prev) => (prev === 'pending' ? 'timeout' : prev));
-      stopPolling();
+      if (active) {
+        setPaymentPollStatus((prev) => (prev === 'pending' ? 'timeout' : prev));
+        stopPolling();
+      }
     }, PAYMENT_POLL_TIMEOUT_MS);
 
-    return stopPolling;
+    return () => {
+      active = false;
+      stopPolling();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [step, paymentInfo?.payment_reference]);
+  }, [step, paymentInfo?.payment_reference, stopPolling]);
 
   const isEmpty = !cart || cart.items.length === 0;
 

--- a/hanna-management-frontend/app/shop/checkout/page.tsx
+++ b/hanna-management-frontend/app/shop/checkout/page.tsx
@@ -23,6 +23,7 @@ interface DeliveryDetails {
 interface PaymentInfo {
   instructions?: string;
   paynow_reference?: string;
+  payment_reference?: string;
   poll_url?: string;
   payment_method?: string;
   requires_otp?: boolean;
@@ -36,6 +37,11 @@ interface PaymentInfo {
 type PaymentMethod = 'ecocash' | 'omari' | 'innbucks' | 'telecash';
 
 type Step = 'details' | 'confirm' | 'pay' | 'success';
+
+type PaymentPollStatus = 'idle' | 'pending' | 'paid' | 'failed' | 'timeout';
+
+const PAYMENT_POLL_INTERVAL_MS = 4000;
+const PAYMENT_POLL_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
 
 const STEPS: { key: Step; label: string }[] = [
   { key: 'details', label: 'Delivery & Payment' },
@@ -146,6 +152,9 @@ export default function CheckoutPage() {
   const [agreedToTerms, setAgreedToTerms] = useState(false);
   const [termsError, setTermsError] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [paymentPollStatus, setPaymentPollStatus] = useState<PaymentPollStatus>('idle');
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     apiClient.get('/crm-api/products/csrf/')
@@ -215,6 +224,7 @@ export default function CheckoutPage() {
       setPaymentInfo({
         instructions: d.instructions,
         paynow_reference: d.paynow_reference,
+        payment_reference: d.payment_reference,
         poll_url: d.poll_url,
         payment_method: d.payment_method || paymentMethod,
         requires_otp: d.requires_otp || false,
@@ -233,7 +243,7 @@ export default function CheckoutPage() {
   };
 
   const submitOTP = async () => {
-    if (!otpCode || !paymentInfo?.paynow_reference) {
+    if (!otpCode || !paymentInfo?.payment_reference) {
       setError('Please enter the OTP code');
       return;
     }
@@ -241,12 +251,14 @@ export default function CheckoutPage() {
     setError(null);
     try {
       const res = await apiClient.post('/crm-api/paynow/submit-otp/', {
-        payment_reference: paymentInfo.paynow_reference,
+        payment_reference: paymentInfo.payment_reference,
         otp_code: otpCode,
       }, csrfHeaders());
       if (res.data?.success) {
         setOtpCode('');
-        setStep('success');
+        // Don't jump straight to "success" - the OTP submission only authorizes
+        // the payment, it doesn't confirm funds were actually received. Let the
+        // status poll (already running for the 'pay' step) confirm completion.
       } else {
         setError(res.data?.message || 'Failed to submit OTP');
       }
@@ -256,6 +268,53 @@ export default function CheckoutPage() {
       setSubmitting(false);
     }
   };
+
+  const stopPolling = useCallback(() => {
+    if (pollIntervalRef.current) { clearInterval(pollIntervalRef.current); pollIntervalRef.current = null; }
+    if (pollTimeoutRef.current) { clearTimeout(pollTimeoutRef.current); pollTimeoutRef.current = null; }
+  }, []);
+
+  // Poll the backend for real payment confirmation while on the 'pay' step.
+  // A mobile-money push can take anywhere from seconds to a couple of minutes
+  // to be authorized, so we can't assume success just because the user clicked
+  // a "done" button - only the backend (via Paynow's IPN or its own poll) knows
+  // whether money actually moved.
+  useEffect(() => {
+    if (step !== 'pay' || !paymentInfo?.payment_reference) {
+      stopPolling();
+      return;
+    }
+
+    setPaymentPollStatus('pending');
+
+    const checkStatus = async () => {
+      try {
+        const res = await apiClient.get(`/crm-api/paynow/payment-status/${paymentInfo.payment_reference}/`);
+        const s = res.data?.status;
+        if (s === 'paid') {
+          setPaymentPollStatus('paid');
+          stopPolling();
+          setStep('success');
+        } else if (s === 'failed') {
+          setPaymentPollStatus('failed');
+          stopPolling();
+        }
+        // 'pending' -> keep polling
+      } catch {
+        // Transient network/API error - keep polling until timeout.
+      }
+    };
+
+    checkStatus();
+    pollIntervalRef.current = setInterval(checkStatus, PAYMENT_POLL_INTERVAL_MS);
+    pollTimeoutRef.current = setTimeout(() => {
+      setPaymentPollStatus((prev) => (prev === 'pending' ? 'timeout' : prev));
+      stopPolling();
+    }, PAYMENT_POLL_TIMEOUT_MS);
+
+    return stopPolling;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step, paymentInfo?.payment_reference]);
 
   const isEmpty = !cart || cart.items.length === 0;
 
@@ -601,18 +660,44 @@ export default function CheckoutPage() {
                     </div>
                   )}
 
-                  <div className="bg-sky-50 border border-sky-100 rounded-xl p-4">
-                    <p className="text-sm text-sky-700 font-medium">
-                      💬 You will receive a WhatsApp confirmation message once payment is complete.
-                    </p>
-                  </div>
+                  {/* Live payment confirmation status */}
+                  {paymentPollStatus === 'pending' && (
+                    <div className="bg-sky-50 border border-sky-100 rounded-xl p-4 flex items-center gap-3">
+                      <div className="w-5 h-5 border-2 border-sky-300 border-t-sky-600 rounded-full animate-spin flex-shrink-0" />
+                      <p className="text-sm text-sky-700 font-medium">
+                        Waiting for payment confirmation… Approve the prompt on your phone.
+                      </p>
+                    </div>
+                  )}
+                  {paymentPollStatus === 'failed' && (
+                    <div className="bg-red-50 border border-red-200 rounded-xl p-4">
+                      <p className="text-sm text-red-700 font-semibold mb-1">Payment was not completed.</p>
+                      <p className="text-xs text-red-600">It may have been cancelled or declined. You can go back and try again, or contact support with your reference above.</p>
+                    </div>
+                  )}
+                  {paymentPollStatus === 'timeout' && (
+                    <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
+                      <p className="text-sm text-amber-700 font-semibold mb-1">Still waiting on confirmation.</p>
+                      <p className="text-xs text-amber-600">This is taking longer than usual. You'll get a WhatsApp message once it's confirmed — you can safely leave this page.</p>
+                    </div>
+                  )}
 
-                  <button
-                    onClick={() => setStep('success')}
-                    className="w-full py-3 bg-purple-600 hover:bg-purple-700 text-white rounded-xl font-bold text-sm transition"
-                  >
-                    Done — Back to Shop
-                  </button>
+                  <div className="flex gap-3">
+                    {(paymentPollStatus === 'failed' || paymentPollStatus === 'timeout') && (
+                      <button
+                        onClick={() => { setError(null); setPaymentPollStatus('idle'); setStep('confirm'); }}
+                        className="flex-1 py-3 bg-orange-500 hover:bg-orange-600 text-white rounded-xl font-bold text-sm transition"
+                      >
+                        Try Again
+                      </button>
+                    )}
+                    <button
+                      onClick={() => router.push('/shop')}
+                      className="flex-1 py-3 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-xl font-bold text-sm transition"
+                    >
+                      Leave &amp; Check Later
+                    </button>
+                  </div>
                 </div>
               )}
 

--- a/whatsappcrm_backend/customer_data/models.py
+++ b/whatsappcrm_backend/customer_data/models.py
@@ -473,7 +473,7 @@ class Payment(models.Model):
     )
     payment_method = models.CharField(_("Payment Method"), max_length=50, default='paynow')
     provider_transaction_id = models.CharField(
-        _("Provider Transaction ID"), max_length=255, blank=True, null=True, db_index=True,
+        _("Provider Transaction ID"), max_length=255, blank=True, null=True, unique=True, db_index=True,
         help_text=_("The unique ID for this transaction from the payment provider (e.g., Paynow poll URL or reference).")
     )
     poll_url = models.CharField(

--- a/whatsappcrm_backend/flows/actions.py
+++ b/whatsappcrm_backend/flows/actions.py
@@ -473,6 +473,7 @@ def checkout_cart_for_contact(contact: Contact, context: Dict[str, Any], params:
     try:
         from products_and_services.models import Cart, CartItem, Product
         from django.db import transaction
+        from django.db.models import F
         from decimal import Decimal
 
         # Find cart by WhatsApp session key
@@ -511,6 +512,14 @@ def checkout_cart_for_contact(contact: Contact, context: Dict[str, Any], params:
             total_amount += unit_price * ci.quantity
 
         with transaction.atomic():
+            # Lock the Product rows so a concurrent checkout can't decrement the
+            # same stock below zero.
+            locked_products = {
+                p.id: p for p in Product.objects.select_for_update().filter(
+                    id__in=[ci.product_id for ci in cart_items]
+                )
+            }
+
             order = Order.objects.create(
                 customer=customer_profile,
                 name=f"AI Shopping Order for {contact.name or contact.whatsapp_id}",
@@ -524,6 +533,7 @@ def checkout_cart_for_contact(contact: Contact, context: Dict[str, Any], params:
             )
 
             order_items_to_create = []
+            oversold_notes = []
             for ci in cart_items:
                 unit_price = ci.product.price or Decimal('0.00')
                 order_items_to_create.append(OrderItem(
@@ -533,8 +543,21 @@ def checkout_cart_for_contact(contact: Contact, context: Dict[str, Any], params:
                     unit_price=unit_price,
                     total_amount=unit_price * ci.quantity
                 ))
+
+                product = locked_products.get(ci.product_id, ci.product)
+                if product.stock_quantity < ci.quantity:
+                    oversold_notes.append(f"{product.name}: ordered {ci.quantity}, only {product.stock_quantity} in stock.")
+                    Product.objects.filter(pk=product.pk).update(stock_quantity=0)
+                else:
+                    Product.objects.filter(pk=product.pk).update(stock_quantity=F('stock_quantity') - ci.quantity)
+
             if order_items_to_create:
                 OrderItem.objects.bulk_create(order_items_to_create)
+
+            if oversold_notes:
+                order.notes = (order.notes or '') + "\n\n⚠️ STOCK SHORTFALL:\n" + "\n".join(oversold_notes)
+                order.save(update_fields=['notes'])
+                logger.warning(f"Order {order.order_number} oversold: {'; '.join(oversold_notes)}")
 
             # Clear cart after creating order
             CartItem.objects.filter(cart=cart).delete()
@@ -757,8 +780,9 @@ def process_cart_order(contact: Contact, context: Dict[str, Any], params: Dict[s
     """
     from .services import _resolve_value
     from django.db import transaction
+    from django.db.models import F
     from django.forms.models import model_to_dict
-    
+
     cart_var = params.get('cart_context_var', 'whatsapp_order_data')
     name_template = params.get('order_name_template', 'WhatsApp Order for {{ contact.name }}')
     save_to_var = params.get('save_order_to')
@@ -778,17 +802,19 @@ def process_cart_order(contact: Contact, context: Dict[str, Any], params: Dict[s
     order_name = _resolve_value(name_template, context, contact)
     customer_profile, _ = CustomerProfile.objects.get_or_create(contact=contact)
     
-    # Get products by their retailer_id (SKU)
+    # Get products by their retailer_id (SKU). Row-locked so concurrent checkouts
+    # can't both decrement the same stock past zero.
     skus = [item.get('product_retailer_id') for item in product_items if item.get('product_retailer_id')]
-    products = Product.objects.filter(sku__in=skus)
-    product_map = {p.sku: p for p in products}
-    
-    if not products.exists():
-        logger.warning(f"No valid products found for SKUs {skus} in WhatsApp order.")
-        return []
-    
+
     try:
         with transaction.atomic():
+            products = Product.objects.select_for_update().filter(sku__in=skus)
+            product_map = {p.sku: p for p in products}
+
+            if not product_map:
+                logger.warning(f"No valid products found for SKUs {skus} in WhatsApp order.")
+                return []
+
             # Generate order number with retry limit
             order_num = None
             max_retries = 100
@@ -797,17 +823,21 @@ def process_cart_order(contact: Contact, context: Dict[str, Any], params: Dict[s
                 if not Order.objects.filter(order_number=candidate).exists():
                     order_num = candidate
                     break
-            
+
             if not order_num:
                 # Fall back to UUID-based number if random attempts exhausted
                 order_num = f"WA-{str(uuid.uuid4().hex[:8]).upper()}"
-            
-            # Calculate total from the items
-            total_amount = sum(
-                Decimal(str(item.get('item_price', 0))) * item.get('quantity', 1)
-                for item in product_items
-            )
-            
+
+            # Calculate total using the authoritative DB price, not whatever price
+            # the WhatsApp catalog payload happens to report.
+            total_amount = Decimal('0.00')
+            for item in product_items:
+                sku = item.get('product_retailer_id')
+                quantity = item.get('quantity', 1)
+                product = product_map.get(sku)
+                unit_price = product.price if product else Decimal(str(item.get('item_price', 0)))
+                total_amount += unit_price * quantity
+
             order = Order.objects.create(
                 customer=customer_profile,
                 name=order_name,
@@ -819,26 +849,40 @@ def process_cart_order(contact: Contact, context: Dict[str, Any], params: Dict[s
                 notes=f"Order placed via WhatsApp Catalog. Contact: {contact.whatsapp_id}",
                 assigned_agent=customer_profile.assigned_agent
             )
-            
+
             order_items_to_create = []
+            oversold_notes = []
             for item in product_items:
                 sku = item.get('product_retailer_id')
                 quantity = item.get('quantity', 1)
-                item_price = Decimal(str(item.get('item_price', 0)))
-                
-                if sku in product_map:
-                    product = product_map[sku]
-                    order_items_to_create.append(OrderItem(
-                        order=order,
-                        product=product,
-                        quantity=quantity,
-                        unit_price=item_price or product.price,
-                        total_amount=(item_price or product.price) * quantity
-                    ))
-            
+
+                product = product_map.get(sku)
+                if not product:
+                    continue
+
+                unit_price = product.price
+                order_items_to_create.append(OrderItem(
+                    order=order,
+                    product=product,
+                    quantity=quantity,
+                    unit_price=unit_price,
+                    total_amount=unit_price * quantity
+                ))
+
+                if product.stock_quantity < quantity:
+                    oversold_notes.append(f"{product.name}: ordered {quantity}, only {product.stock_quantity} in stock.")
+                    Product.objects.filter(pk=product.pk).update(stock_quantity=0)
+                else:
+                    Product.objects.filter(pk=product.pk).update(stock_quantity=F('stock_quantity') - quantity)
+
             if order_items_to_create:
                 OrderItem.objects.bulk_create(order_items_to_create)
-            
+
+            if oversold_notes:
+                order.notes = (order.notes or '') + "\n\n⚠️ STOCK SHORTFALL:\n" + "\n".join(oversold_notes)
+                order.save(update_fields=['notes'])
+                logger.warning(f"Order {order.order_number} oversold: {'; '.join(oversold_notes)}")
+
             logger.info(f"Created Order (ID: {order.id}, Number: {order_num}) with {len(order_items_to_create)} items from WhatsApp catalog for contact {contact.id}.")
             
             if save_to_var:
@@ -1117,32 +1161,25 @@ def confirm_payment_method_and_initiate(contact: Contact, context: Dict[str, Any
     actions_to_perform = []
     
     # Check if it's a Paynow method (automated) or manual
-    from customer_data.payment_utils import is_automated_payment_method
+    from customer_data.payment_utils import is_automated_payment_method, validate_phone_number
     if is_automated_payment_method(payment_method):
-        # Automated Paynow payment - send confirmation and initiate payment
-        paynow_method_map = {
+        # Automated Paynow payment - actually initiate the payment via Paynow.
+        # Previously this branch only told the customer to "check your phone"
+        # without ever calling Paynow, so no payment prompt was ever sent.
+        method_display_map = {
             'paynow_ecocash': 'Ecocash',
             'paynow_onemoney': 'OneMoney',
             'paynow_innbucks': 'Innbucks'
         }
-        method_display = paynow_method_map.get(payment_method, 'Paynow')
-        
-        confirmation_msg = (
-            f"✅ *Payment Method Confirmed*\n\n"
-            f"You have selected: *{method_display}*\n\n"
-            f"Order: #{order.order_number}\n"
-            f"Amount: ${order.amount} {order.currency}\n\n"
-            f"Please check your phone for the payment prompt..."
-        )
-        
-        actions_to_perform.append({
-            'type': 'send_whatsapp_message',
-            'recipient_wa_id': contact.whatsapp_id,
-            'message_type': 'text',
-            'data': {'body': confirmation_msg}
-        })
-        
-        # Store order data back to context for payment initiation
+        paynow_method_type_map = {
+            'paynow_ecocash': 'ecocash',
+            'paynow_onemoney': 'onemoney',
+            'paynow_innbucks': 'innbucks'
+        }
+        method_display = method_display_map.get(payment_method, 'Paynow')
+        paynow_method_type = paynow_method_type_map.get(payment_method, 'ecocash')
+
+        # Store order data back to context for downstream flow steps
         context[order_var] = {
             'id': str(order.id),
             'order_number': order.order_number,
@@ -1150,7 +1187,84 @@ def confirm_payment_method_and_initiate(contact: Contact, context: Dict[str, Any
             'currency': order.currency,
             'payment_method': payment_method
         }
-        
+
+        try:
+            from paynow_integration.services import PaynowService
+            from customer_data.models import Payment, PaymentStatus
+            from decimal import Decimal
+            import uuid
+
+            validated_phone = validate_phone_number(contact.whatsapp_id)
+            customer_email = (order.customer.email if order.customer else '') or 'mnyemba@hanna.co.zw'
+            payment_reference = f"PAY-{order.order_number}-{uuid.uuid4().hex[:8].upper()}"
+
+            paynow_service = PaynowService(ipn_callback_url='/crm-api/paynow/ipn/')
+            payment = Payment.objects.create(
+                customer=order.customer,
+                order=order,
+                amount=order.amount,
+                currency=order.currency,
+                status=PaymentStatus.PENDING,
+                payment_method=paynow_method_type,
+                provider_transaction_id=payment_reference
+            )
+
+            result = paynow_service.initiate_express_checkout_payment(
+                amount=Decimal(str(order.amount)),
+                reference=payment_reference,
+                phone_number=validated_phone,
+                email=customer_email,
+                paynow_method_type=paynow_method_type,
+                description=f"Payment for Order {order.order_number}"
+            )
+
+            if result.get('success'):
+                payment.poll_url = result.get('poll_url')
+                payment.provider_response = result
+                payment.save(update_fields=['poll_url', 'provider_response'])
+                order.payment_status = Order.PaymentStatus.PENDING
+                order.save(update_fields=['payment_status'])
+
+                instructions = result.get('instructions') or f"Please check your {method_display} to complete the payment."
+                confirmation_msg = (
+                    f"✅ *Payment Method Confirmed*\n\n"
+                    f"You have selected: *{method_display}*\n\n"
+                    f"Order: #{order.order_number}\n"
+                    f"Amount: ${order.amount} {order.currency}\n\n"
+                    f"{instructions}"
+                )
+            else:
+                payment.status = PaymentStatus.FAILED
+                payment.provider_response = result
+                payment.save(update_fields=['status', 'provider_response'])
+                confirmation_msg = (
+                    f"❌ We couldn't start your {method_display} payment.\n\n"
+                    f"{result.get('message', 'Please try again or contact support.')}\n\n"
+                    f"Order: #{order.order_number}"
+                )
+        except ValueError as e:
+            # validate_phone_number raises ValueError on invalid phone
+            logger.error(f"Phone number validation failed for contact {contact.id}: {e}")
+            confirmation_msg = (
+                f"❌ We couldn't verify your phone number for payment.\n\n"
+                f"Please contact our support team to complete your payment.\n"
+                f"Order: #{order.order_number}"
+            )
+        except Exception as e:
+            logger.error(f"Error initiating Paynow payment for order {order.order_number}: {e}", exc_info=True)
+            confirmation_msg = (
+                f"❌ Something went wrong starting your payment.\n\n"
+                f"Please try again or contact support.\n"
+                f"Order: #{order.order_number}"
+            )
+
+        actions_to_perform.append({
+            'type': 'send_whatsapp_message',
+            'recipient_wa_id': contact.whatsapp_id,
+            'message_type': 'text',
+            'data': {'body': confirmation_msg}
+        })
+
     else:
         # Manual payment - send instructions
         from customer_data.payment_utils import get_bank_transfer_instructions, get_cash_payment_instructions

--- a/whatsappcrm_backend/flows/actions.py
+++ b/whatsappcrm_backend/flows/actions.py
@@ -1225,6 +1225,15 @@ def confirm_payment_method_and_initiate(contact: Contact, context: Dict[str, Any
                 order.payment_status = Order.PaymentStatus.PENDING
                 order.save(update_fields=['payment_status'])
 
+                # Fallback in case the Paynow IPN callback never arrives.
+                if payment.poll_url:
+                    from django.db import transaction
+                    from paynow_integration.tasks import poll_paynow_transaction_status
+                    payment_id = str(payment.id)
+                    transaction.on_commit(
+                        lambda: poll_paynow_transaction_status.apply_async(args=[payment_id], countdown=90)
+                    )
+
                 instructions = result.get('instructions') or f"Please check your {method_display} to complete the payment."
                 confirmation_msg = (
                     f"✅ *Payment Method Confirmed*\n\n"

--- a/whatsappcrm_backend/flows/services.py
+++ b/whatsappcrm_backend/flows/services.py
@@ -2029,86 +2029,119 @@ def process_order_from_catalog(msg_data: dict, contact: Contact, app_config) -> 
     from meta_integration.utils import send_whatsapp_message
     from .models import WhatsAppFlow
     from decimal import Decimal
+    from django.db import transaction
+    from django.db.models import F
     import random
-    
+
     try:
         order_data = msg_data.get("order", {})
         catalog_id = order_data.get("catalog_id")
         product_items = order_data.get("product_items", [])
         text_message = order_data.get("text", "")  # Optional message from customer
-        
+
         if not product_items:
             logger.warning(f"Order message has no product items: {msg_data}")
             return False, 'No product items in order'
-        
+
         logger.info(f"Processing WhatsApp catalog order for contact {contact.id} with {len(product_items)} items.")
-        
+
         # Get or create customer profile
         customer_profile, created = CustomerProfile.objects.get_or_create(contact=contact)
         if created:
             logger.info(f"Created new CustomerProfile for contact {contact.id}")
-        
+
         # Get products by their retailer_id (SKU)
         skus = [item.get('product_retailer_id') for item in product_items if item.get('product_retailer_id')]
-        products = Product.objects.filter(sku__in=skus)
-        product_map = {p.sku: p for p in products}
-        
-        # Generate unique order number with retry limit
-        import uuid as uuid_module
-        order_num = None
-        max_retries = 100
-        for _ in range(max_retries):
-            candidate = f"WA-{random.randint(10000, 99999)}"
-            if not Order.objects.filter(order_number=candidate).exists():
-                order_num = candidate
-                break
-        
-        if not order_num:
-            # Fall back to UUID-based number if random attempts exhausted
-            order_num = f"WA-{str(uuid_module.uuid4().hex[:8]).upper()}"
-        
-        # Calculate total from the items
+
+        oversold_notes = []
+        order = None
+        order_items_created = []
         total_amount = Decimal('0.00')
         currency = 'USD'
-        for item in product_items:
-            item_price = Decimal(str(item.get('item_price', '0')))
-            quantity = int(item.get('quantity', 1))
-            total_amount += item_price * quantity
-            currency = item.get('currency', 'USD')
-        
-        # Create the order
-        order = Order.objects.create(
-            customer=customer_profile,
-            name=f"WhatsApp Catalog Order for {contact.name or contact.whatsapp_id}",
-            order_number=order_num,
-            stage=Order.Stage.CLOSED_WON,
-            payment_status=Order.PaymentStatus.PENDING,
-            amount=total_amount,
-            currency=currency,
-            notes=f"Order placed via WhatsApp Catalog.\nCatalog ID: {catalog_id}\nCustomer Note: {text_message}",
-            assigned_agent=customer_profile.assigned_agent
-        )
-        
-        # Create order items
-        order_items_created = []
-        for item in product_items:
-            sku = item.get('product_retailer_id')
-            quantity = int(item.get('quantity', 1))
-            item_price = Decimal(str(item.get('item_price', '0')))
-            
-            product = product_map.get(sku)
-            if product:
+
+        # Wrap order + item creation + stock deduction in a single transaction so a
+        # failure partway through never leaves an Order with a total that doesn't
+        # match its items, and lock Product rows so concurrent orders can't both
+        # decrement the same stock past zero.
+        with transaction.atomic():
+            products = Product.objects.select_for_update().filter(sku__in=skus)
+            product_map = {p.sku: p for p in products}
+
+            # Generate unique order number with retry limit
+            import uuid as uuid_module
+            order_num = None
+            max_retries = 100
+            for _ in range(max_retries):
+                candidate = f"WA-{random.randint(10000, 99999)}"
+                if not Order.objects.filter(order_number=candidate).exists():
+                    order_num = candidate
+                    break
+
+            if not order_num:
+                # Fall back to UUID-based number if random attempts exhausted
+                order_num = f"WA-{str(uuid_module.uuid4().hex[:8]).upper()}"
+
+            # Calculate total from the items using the authoritative DB price, not
+            # whatever price the WhatsApp catalog webhook happens to report (that
+            # catalog data can drift from Product.price after a sync lag or manual
+            # catalog edit).
+            for item in product_items:
+                sku = item.get('product_retailer_id')
+                quantity = int(item.get('quantity', 1))
+                product = product_map.get(sku)
+                unit_price = product.price if product else Decimal(str(item.get('item_price', '0')))
+                total_amount += unit_price * quantity
+                currency = item.get('currency', currency)
+
+            # Create the order
+            order = Order.objects.create(
+                customer=customer_profile,
+                name=f"WhatsApp Catalog Order for {contact.name or contact.whatsapp_id}",
+                order_number=order_num,
+                stage=Order.Stage.CLOSED_WON,
+                payment_status=Order.PaymentStatus.PENDING,
+                amount=total_amount,
+                currency=currency,
+                notes=f"Order placed via WhatsApp Catalog.\nCatalog ID: {catalog_id}\nCustomer Note: {text_message}",
+                assigned_agent=customer_profile.assigned_agent
+            )
+
+            # Create order items and atomically deduct stock
+            for item in product_items:
+                sku = item.get('product_retailer_id')
+                quantity = int(item.get('quantity', 1))
+                product = product_map.get(sku)
+
+                if not product:
+                    logger.warning(f"Product with SKU '{sku}' not found in database for WhatsApp order.")
+                    continue
+
+                unit_price = product.price
                 order_item = OrderItem.objects.create(
                     order=order,
                     product=product,
                     quantity=quantity,
-                    unit_price=item_price or product.price,
-                    total_amount=(item_price or product.price) * quantity
+                    unit_price=unit_price,
+                    total_amount=unit_price * quantity
                 )
                 order_items_created.append(order_item)
-            else:
-                logger.warning(f"Product with SKU '{sku}' not found in database for WhatsApp order.")
-        
+
+                # The order is already committed on WhatsApp's side by this point, so
+                # we can't reject it here for insufficient stock - instead we floor
+                # stock at zero and flag the shortfall for staff follow-up/backorder.
+                if product.stock_quantity < quantity:
+                    oversold_notes.append(
+                        f"{product.name}: ordered {quantity}, only {product.stock_quantity} in stock."
+                    )
+                    Product.objects.filter(pk=product.pk).update(stock_quantity=0)
+                else:
+                    Product.objects.filter(pk=product.pk).update(stock_quantity=F('stock_quantity') - quantity)
+
+            if oversold_notes:
+                order.notes = (order.notes or '') + "\n\n⚠️ STOCK SHORTFALL:\n" + "\n".join(oversold_notes)
+                order.save(update_fields=['notes'])
+                logger.warning(f"Order {order.order_number} oversold: {'; '.join(oversold_notes)}")
+
         logger.info(f"Created Order {order.order_number} with {len(order_items_created)} items for contact {contact.id}.")
         
         # Send confirmation message

--- a/whatsappcrm_backend/meta_integration/views.py
+++ b/whatsappcrm_backend/meta_integration/views.py
@@ -503,7 +503,8 @@ class MetaWebhookAPIView(View):
             # guard, a retried flow-response (e.g. a submitted payment form) would be
             # processed a second time, potentially double-initiating a payment.
             logger.info(f"Flow response with WAMID {whatsapp_message_id} already processed. Skipping duplicate processing.")
-            self._save_log(log_entry, 'processed', 'Duplicate webhook delivery ignored (already processed).')
+            if log_entry:
+                self._save_log(log_entry, 'processed', 'Duplicate webhook delivery ignored (already processed).')
             return
 
         # Process the WhatsApp flow response data
@@ -550,7 +551,8 @@ class MetaWebhookAPIView(View):
         )
         if not msg_created:
             logger.info(f"Order message with WAMID {whatsapp_message_id} already processed. Skipping duplicate order creation.")
-            self._save_log(log_entry, 'processed', 'Duplicate webhook delivery ignored (order already created).')
+            if log_entry:
+                self._save_log(log_entry, 'processed', 'Duplicate webhook delivery ignored (order already created).')
             return
 
         success, notes = process_order_from_catalog(msg_data, contact, active_config)

--- a/whatsappcrm_backend/meta_integration/views.py
+++ b/whatsappcrm_backend/meta_integration/views.py
@@ -497,7 +497,15 @@ class MetaWebhookAPIView(View):
         if log_entry and log_entry.pk:
             log_entry.message = incoming_msg_obj
             log_entry.save(update_fields=['message'])
-        
+
+        if not msg_created:
+            # Meta retries webhook delivery on non-2xx/slow responses. Without this
+            # guard, a retried flow-response (e.g. a submitted payment form) would be
+            # processed a second time, potentially double-initiating a payment.
+            logger.info(f"Flow response with WAMID {whatsapp_message_id} already processed. Skipping duplicate processing.")
+            self._save_log(log_entry, 'processed', 'Duplicate webhook delivery ignored (already processed).')
+            return
+
         # Process the WhatsApp flow response data
         success, notes = process_whatsapp_flow_response(msg_data, contact, active_config)
         
@@ -518,8 +526,33 @@ class MetaWebhookAPIView(View):
         Handles order messages from WhatsApp catalog.
         Processes the cart, creates an order, and initiates payment flow.
         """
+        from conversations.models import Message
         from flows.services import process_order_from_catalog
-        
+
+        whatsapp_message_id = msg_data.get("id")
+
+        # Meta retries webhook delivery on non-2xx/slow responses. This code path
+        # creates a brand-new Order with no idempotency key of its own, so without
+        # recording the wamid here, a retried delivery would create a duplicate
+        # Order for the same WhatsApp catalog checkout.
+        _, msg_created = Message.objects.get_or_create(
+            wamid=whatsapp_message_id,
+            defaults={
+                'contact': contact,
+                'app_config': active_config,
+                'direction': 'in',
+                'message_type': 'order',
+                'content_payload': msg_data,
+                'timestamp': timezone.now(),
+                'status': 'delivered',
+                'status_timestamp': timezone.now(),
+            }
+        )
+        if not msg_created:
+            logger.info(f"Order message with WAMID {whatsapp_message_id} already processed. Skipping duplicate order creation.")
+            self._save_log(log_entry, 'processed', 'Duplicate webhook delivery ignored (order already created).')
+            return
+
         success, notes = process_order_from_catalog(msg_data, contact, active_config)
         
         if success:
@@ -741,7 +774,15 @@ class MetaWebhookAPIView(View):
                         payment.poll_url = result.get('poll_url')
                         payment.provider_response = result
                         payment.save(update_fields=['poll_url', 'provider_response'])
-                        
+
+                        # Fallback in case the Paynow IPN callback never arrives.
+                        if payment.poll_url:
+                            from paynow_integration.tasks import poll_paynow_transaction_status
+                            payment_id = str(payment.id)
+                            transaction.on_commit(
+                                lambda: poll_paynow_transaction_status.apply_async(args=[payment_id], countdown=90)
+                            )
+
                         success_msg = (
                             f"💳 *Payment Request Sent*\n\n"
                             f"Please approve the payment on your phone.\n\n"

--- a/whatsappcrm_backend/paynow_integration/paynow_wrapper.py
+++ b/whatsappcrm_backend/paynow_integration/paynow_wrapper.py
@@ -1,4 +1,5 @@
 # paynow_wrapper.py
+import hmac
 import logging
 import hashlib # Still needed for IPN verification
 from decimal import Decimal
@@ -148,25 +149,29 @@ class PaynowSDK: # This class will wrap the official Paynow SDK
             logger.error(f"PaynowSDK: Unexpected error during Express Checkout initiation: {str(e)}", exc_info=True)
             return {"success": False, "message": f"Internal error processing payment: {str(e)}"}
 
-    def verify_ipn_callback(self, ipn_data: Dict[str, str]) -> bool:
+    def verify_ipn_hash(self, ipn_data: Dict[str, str]) -> bool:
         """
         Verifies the integrity of an IPN callback from Paynow using the generated hash.
         The official SDK does not provide a direct IPN verification method,
         so we retain our manual hash verification logic.
+
+        Per Paynow's IPN spec, the hash is computed over the concatenated
+        *values* of every field Paynow sends (excluding the `hash` field
+        itself), in the order they were sent, with the integration key
+        appended, then MD5-hashed and upper-cased. Hardcoding a fixed subset
+        of fields (status/reference/paynowreference/amount) does not match
+        real IPN payloads, which can include additional fields (e.g. pollurl).
         """
-        hash_received = ipn_data.get('hash')
-        
-        status = ipn_data.get('status', '')
-        reference = ipn_data.get('reference', '')
-        paynow_reference = ipn_data.get('paynowreference', '')
-        amount = ipn_data.get('amount', '')
-        
-        # The IPN hash calculation is specific and usually involves these fields + integration key.
-        # This is based on common Paynow IPN documentation patterns.
-        expected_hash_string = f"{status}{reference}{paynow_reference}{amount}{self.integration_key}"
+        hash_received = (ipn_data.get('hash') or '').upper()
+        if not hash_received:
+            return False
+
+        values = ''.join(str(v) for k, v in ipn_data.items() if k.lower() != 'hash')
+        expected_hash_string = f"{values}{self.integration_key}"
         expected_hash = hashlib.md5(expected_hash_string.encode('utf-8')).hexdigest().upper()
-        
-        return hash_received == expected_hash
+
+        # Constant-time comparison to avoid timing side-channels.
+        return hmac.compare_digest(hash_received, expected_hash)
 
     def check_transaction_status(self, poll_url: str) -> Dict[str, Any]:
         """

--- a/whatsappcrm_backend/paynow_integration/tasks.py
+++ b/whatsappcrm_backend/paynow_integration/tasks.py
@@ -1,285 +1,130 @@
 # paynow_integration/tasks.py
+"""
+Celery fallback for confirming Paynow payments when the IPN callback never
+arrives (webhooks are inherently unreliable - network blips, Paynow
+misconfiguration, a firewall dropping the callback, etc). This polls
+Paynow's poll_url directly for the transaction status and applies the same
+idempotent update as the IPN handler in views.py.
+"""
 import logging
-from typing import Optional
-from celery import shared_task
 import random
+
+from celery import shared_task
 from django.db import transaction
-from django.urls import reverse
-from django.utils import timezone
-from django.conf import settings
 
 from .services import PaynowService
-from meta_integration.utils import send_whatsapp_message, create_text_message_data
-from customer_data.models import Payment, Order
+from customer_data.models import Payment, PaymentStatus, Order
 
 logger = logging.getLogger(__name__)
 
-# --- Helper Functions ---
+# Must match paynow_integration/views.py PAYNOW_IPN_URL_PATH.
+PAYNOW_IPN_URL_PATH = '/crm-api/paynow/ipn/'
 
-def _fail_payment_in_db(payment_obj: Payment, reason: str) -> Optional[Payment]:
-    """
-    Internal helper to mark a Payment as FAILED in the database.
-    This is NOT a Celery task. It returns the failed payment on success, or None.
-    """
-    log_prefix = f"[DB Fail Helper - Ref: {payment_obj.id}]"
-    logger.warning(f"{log_prefix} Attempting to fail payment in DB. Reason: {reason}")
 
-    payment_to_fail = None
-    try:
-        with transaction.atomic():
-            # Atomically fetch and lock the payment ONLY if it's still PENDING.
-            payment_to_fail = Payment.objects.select_for_update().get(
-                pk=payment_obj.pk,
-                status='pending'
-            )
-            
-            payment_to_fail.status = 'failed'
-            payment_to_fail.notes = (payment_to_fail.notes or "") + f"\nFailure reason: {reason[:255]}"
-            payment_to_fail.save(update_fields=['status', 'notes', 'updated_at'])
-            logger.info(f"{log_prefix} Successfully marked payment as FAILED in the database.")
-            
-    except Payment.DoesNotExist:
-        # This is not an error. It means the payment was already processed.
-        logger.info(
-            f"{log_prefix} Payment was not in PENDING state "
-            "when attempting to fail. It was likely already processed. No action taken."
-        )
-        return None
-
-    return payment_to_fail
-
-def _fail_payment_and_notify_user(payment_obj: Payment, reason: str):
-    """
-    Marks a payment as failed in the DB and sends a notification to the user.
-    """
-    log_prefix = f"[Fail & Notify - Ref: {payment_obj.id}]"
-    failed_payment = _fail_payment_in_db(payment_obj, reason)
-    
-    if failed_payment and failed_payment.contact:
-        # If the payment was successfully marked as failed, notify the user.
-        send_payment_failure_notification_task.delay(str(failed_payment.id))
-    elif not failed_payment:
-        logger.info(f"{log_prefix} Payment was not failed in DB (likely already processed), so no notification will be sent.")
-    elif not payment_obj.contact:
-        logger.warning(f"{log_prefix} Payment was failed in DB, but no contact is associated to send notification.")
-
-# --- Celery Tasks ---
-
-@shared_task(name="paynow_integration.send_payment_failure_notification_task")
-def send_payment_failure_notification_task(payment_id: str):
-    """
-    Sends a WhatsApp message to the user notifying them of a failed payment.
-    """
-    log_prefix = f"[Failure Notif Task - Ref: {payment_id}]"
-    logger.info(f"{log_prefix} Preparing to send failure notification.")
-    try:
-        # Eager load related objects to avoid extra queries
-        payment = Payment.objects.select_related('contact', 'member').get(id=payment_id)
-        contact_to_notify = payment.contact
-        
-        if not contact_to_notify:
-            logger.error(f"{log_prefix} Could not find contact associated with payment to send failure notification.")
-            return
-
-        # Personalize the greeting
-        full_name = payment.member.get_full_name() if payment.member and payment.member.get_full_name() else payment.contact.name
-        recipient_name = full_name or 'church member'
-        admin_contact_number = settings.ADMIN_WHATSAPP_NUMBER
-        contact_info = f"You can reach us on WhatsApp at: wa.me/{admin_contact_number.replace('+', '')}" if admin_contact_number else "Please visit the church office for assistance."
-
-        failure_message = (
-            f"Greetings {recipient_name},\n\n"
-            f"We encountered an issue while processing your contribution of *{payment.currency} {payment.amount:.2f}*.\n\n"
-            "Please don't worry, no funds have been deducted for this attempt. If you'd like to try again or need help, our team is here to assist.\n\n"
-            f"{contact_info}\n\n"
-            "\"The Lord is my strength and my shield; in him my heart trusts, and I am helped.\" - Psalm 28:7\n\n"
-            "Blessings,\n"
-            "The Church Accounts Team"
-        )
-        message_data = create_text_message_data(text_body=failure_message)
-        send_whatsapp_message(to_phone_number=contact_to_notify.whatsapp_id, message_type='text', data=message_data)
-        logger.info(f"{log_prefix} Successfully sent failure notification to user {contact_to_notify.whatsapp_id}.")
-    except Payment.DoesNotExist:
-        logger.error(f"{log_prefix} Could not find payment to send failure notification.")
-    except Exception as e:
-        logger.error(f"{log_prefix} Error sending failure notification: {e}", exc_info=True)
-
-@shared_task(name="paynow_integration.send_giving_confirmation_whatsapp")
-def send_giving_confirmation_whatsapp(payment_id: str):
-    """
-    Sends a WhatsApp message to the user confirming their successful contribution.
-    """
-    log_prefix = f"[Giving Confirm Task - Ref: {payment_id}]"
-    logger.info(f"{log_prefix} Preparing to send giving confirmation.")
-    try:
-        # Eager load related objects
-        payment = Payment.objects.select_related('contact', 'member').get(id=payment_id, status='completed')
-        contact_to_notify = payment.contact
-
-        if not contact_to_notify:
-            logger.error(f"{log_prefix} Could not find contact associated with payment to send confirmation.")
-            return
-
-        # Personalize the greeting
-        full_name = payment.member.get_full_name() if payment.member and payment.member.get_full_name() else payment.contact.name
-        recipient_name = full_name or 'church member'
-
-        confirmation_message = (
-            f"Dear {recipient_name},\n\n"
-            f"Praise God! We confirm with thanks the receipt of your contribution of *{payment.currency} {payment.amount:.2f}*.\n\n"
-            "Your faithfulness and generosity are a blessing to the ministry. We pray for God's abundant blessings upon you and your family.\n\n"
-            "\"Each of you should give what you have decided in your heart to give, not reluctantly or under compulsion, for God loves a cheerful giver.\" - 2 Corinthians 9:7\n\n"
-            "In His Grace,\n"
-            "The Church Accounts Team"
-        )
-        message_data = create_text_message_data(text_body=confirmation_message)
-        send_whatsapp_message(to_phone_number=contact_to_notify.whatsapp_id, message_type='text', data=message_data)
-        logger.info(f"{log_prefix} Successfully sent giving confirmation to user {contact_to_notify.whatsapp_id}.")
-    except Payment.DoesNotExist:
-        logger.error(f"{log_prefix} Could not find completed payment to send confirmation.")
-    except Exception as e:
-        logger.error(f"{log_prefix} Error sending giving confirmation: {e}", exc_info=True)
-
-@shared_task(name="paynow_integration.poll_paynow_transaction_status", bind=True, max_retries=10, default_retry_delay=120)
+@shared_task(name="paynow_integration.poll_paynow_transaction_status", bind=True, max_retries=8, default_retry_delay=60)
 def poll_paynow_transaction_status(self, payment_id: str):
     """
-    Polls Paynow to get the transaction status and updates the Payment record accordingly.
+    Polls Paynow for the current status of a payment and updates the Payment/
+    Order records accordingly. Intended to be scheduled a short delay after
+    payment initiation as a safety net for missed IPNs - it's idempotent with
+    the IPN handler (both check `status` before applying side effects), so it's
+    safe for both to eventually observe the same "paid" transaction.
     """
-    log_prefix = f"[Poll Task - Ref: {payment_id}]"
-    logger.info(f"{log_prefix} Polling Paynow status. Attempt {self.request.retries + 1}/{self.max_retries + 1}.")
+    log_prefix = f"[Paynow Poll - Payment: {payment_id}]"
+
     try:
         with transaction.atomic():
-            # Lock the Payment row to prevent race conditions from IPNs or other tasks.
-            pending_payment = Payment.objects.select_for_update().get(id=payment_id, status='pending')
-            
-            # FIX: The PaynowService requires the IPN callback URL for initialization.
             try:
-                ipn_url = reverse('customer_data_api:paynow-ipn-webhook')
-                paynow_service = PaynowService(ipn_callback_url=ipn_url)
-            except Exception as e:
-                logger.error(f"{log_prefix} Failed to initialize PaynowService. Error: {e}", exc_info=True)
-                _fail_payment_and_notify_user(pending_payment, "Could not initialize payment service for polling.")
-                return # Stop execution
-
-            poll_url = pending_payment.external_data.get('poll_url')
-            if not poll_url:
-                logger.error(f"{log_prefix} Poll URL not found. Failing payment.")
-                _fail_payment_and_notify_user(pending_payment, "Could not poll status: Poll URL missing.")
-                return # Stop execution
-
-            logger.debug(f"{log_prefix} Checking poll URL: {poll_url}")
-            status_response = paynow_service.check_transaction_status(poll_url)
-            
-            if status_response['success']:
-                paynow_status = status_response.get('status', 'unknown').lower()
-                logger.info(f"{log_prefix} Paynow status received: '{paynow_status}'.")
-
-                if paynow_status == 'paid':
-                    pending_payment.status = 'completed'
-                    pending_payment.notes = (pending_payment.notes or "") + f"\nPaynow Ref: {pending_payment.transaction_reference}"
-                    pending_payment.save(update_fields=['status', 'notes', 'updated_at'])
-                    
-                    # --- NEW: Update associated order status ---
-                    if pending_payment.order:
-                        pending_payment.order.payment_status = Order.PaymentStatus.PAID
-                        pending_payment.order.save(update_fields=['payment_status', 'updated_at'])
-                        logger.info(f"{log_prefix} Updated order {pending_payment.order.id} payment_status to PAID.")
-                    
-                    logger.info(f"{log_prefix} Successfully processed payment {pending_payment.id}. Amount: {pending_payment.amount}.")
-                    
-                    # Send confirmation to user
-                    send_giving_confirmation_whatsapp.delay(payment_id=str(pending_payment.id))
-                    return # Task is complete
-
-                elif paynow_status in ['cancelled', 'failed', 'disputed']:
-                    reason = f"Paynow transaction status was '{paynow_status}'."
-                    logger.warning(f"{log_prefix} Failing payment due to status: '{paynow_status}'.")
-                    _fail_payment_and_notify_user(pending_payment, reason)
-                    return # Task is complete
-
-                else: # 'pending', 'created', 'sent', etc.
-                    # Implement exponential backoff with jitter to reduce load on Paynow's servers.
-                    retry_delay = 60 * (2 ** self.request.retries)
-                    retry_delay_with_jitter = retry_delay + random.randint(0, 15)
-                    logger.info(f"{log_prefix} Transaction is still pending with status '{paynow_status}'. Retrying in {retry_delay_with_jitter} seconds.")
-                    self.retry(exc=Exception(f"Transaction is still pending. Current status: {paynow_status}"), countdown=retry_delay_with_jitter)
-            else:
-                error_msg = status_response.get('message', 'Unknown API error')
-                logger.error(f"{log_prefix} Failed to get Paynow status: {error_msg}. Retrying task.")
-                self.retry(exc=Exception(f"Failed to get Paynow status: {error_msg}"))
-
-    except Payment.DoesNotExist:
-        logger.info(f"{log_prefix} Payment not found or not PENDING. It was likely processed by another task. Stopping poll.")
-    except Exception as e:
-        logger.error(f"{log_prefix} Unhandled error during polling: {e}", exc_info=True)
-        try:
-            self.retry(exc=e)
-        except self.MaxRetriesExceededError:
-            logger.error(f"{log_prefix} Max retries exceeded. Attempting to fail payment.")
-            try:
-                payment_to_fail = Payment.objects.get(id=payment_id, status='pending')
-                _fail_payment_and_notify_user(payment_to_fail, f"Polling failed after max retries: {str(e)[:100]}")
+                payment = Payment.objects.select_for_update().get(id=payment_id)
             except Payment.DoesNotExist:
-                logger.warning(f"{log_prefix} Could not find payment to fail after max retries (it might have been processed or failed already).")
-            except Exception as final_fail_exc:
-                logger.critical(f"{log_prefix} Could not fail payment after max retries: {final_fail_exc}")
+                logger.warning(f"{log_prefix} Payment not found. Stopping poll.")
+                return
 
-@shared_task(name="paynow_integration.process_paynow_ipn_task")
-def process_paynow_ipn_task(ipn_data: dict):
-    """
-    Processes a Paynow IPN message. It verifies the IPN hash, then updates
-    the payment status directly. This is the primary confirmation method.
-    """
-    reference = ipn_data.get('reference')
-    if not reference:
-        logger.error("[IPN Task] Received IPN data without a reference. Cannot process.")
-        return
+            if payment.status != PaymentStatus.PENDING:
+                logger.info(f"{log_prefix} Payment already in terminal/non-pending state '{payment.status}'. Stopping poll.")
+                return
 
-    log_prefix = f"[IPN Task - Ref: {reference}]"
-    logger.info(f"{log_prefix} Starting to process IPN data: {ipn_data}")
+            if not payment.poll_url:
+                logger.warning(f"{log_prefix} No poll_url on payment; cannot poll. Stopping.")
+                return
 
-    # The service needs a URL for init, even if we're just verifying a hash.
-    try:
-        ipn_url = reverse('customer_data_api:paynow-ipn-webhook')
-        paynow_service = PaynowService(ipn_callback_url=ipn_url)
-    except Exception as e:
-        logger.error(f"{log_prefix} Failed to initialize PaynowService for IPN processing. Error: {e}", exc_info=True)
-        return # Cannot proceed without the service
+            paynow_service = PaynowService(ipn_callback_url=PAYNOW_IPN_URL_PATH)
+            status_response = paynow_service.check_transaction_status(payment.poll_url)
 
-    if not paynow_service.verify_ipn_hash(ipn_data):
-        logger.error(f"{log_prefix} IPN hash verification failed. Discarding message.")
-        return
+            if not status_response.get('success'):
+                error_msg = status_response.get('message', 'Unknown error')
+                logger.warning(f"{log_prefix} Failed to check status: {error_msg}. Will retry.")
+                raise self.retry(exc=Exception(error_msg))
 
-    logger.info(f"{log_prefix} IPN hash verified successfully.")
-    paynow_status = ipn_data.get('status', 'unknown').lower()
-
-    try:
-        with transaction.atomic():
-            # Lock the payment record to prevent race conditions with polling tasks.
-            payment_to_update = Payment.objects.select_for_update().get(pk=reference, status='pending')
+            paynow_status = (status_response.get('status') or '').lower()
 
             if paynow_status == 'paid':
-                payment_to_update.status = 'completed'
-                payment_to_update.transaction_reference = ipn_data.get('paynowreference')
-                payment_to_update.notes = (payment_to_update.notes or "") + f"\nConfirmed via IPN. Paynow Ref: {payment_to_update.transaction_reference}"
-                payment_to_update.save(update_fields=['status', 'transaction_reference', 'notes', 'updated_at'])
+                payment.status = PaymentStatus.SUCCESSFUL
+                payment.provider_response = {**(payment.provider_response or {}), 'poll_status': status_response}
+                payment.save(update_fields=['status', 'provider_response', 'updated_at'])
 
-                # --- NEW: Update associated order status ---
-                if payment_to_update.order:
-                    payment_to_update.order.payment_status = Order.PaymentStatus.PAID
-                    payment_to_update.order.save(update_fields=['payment_status', 'updated_at'])
-                    logger.info(f"{log_prefix} Updated order {payment_to_update.order.id} payment_status to PAID.")
-                
-                logger.info(f"{log_prefix} Successfully processed payment. Amount: {payment_to_update.amount}.")
-                send_giving_confirmation_whatsapp.delay(payment_id=str(payment_to_update.id))
-            
-            elif paynow_status in ['cancelled', 'failed', 'disputed']:
-                reason = f"Paynow IPN reported status: '{paynow_status}'."
-                logger.warning(f"{log_prefix} Failing payment due to IPN status: '{paynow_status}'.")
-                _fail_payment_and_notify_user(payment_to_update, reason)
-            
+                if payment.order:
+                    payment.order.payment_status = Order.PaymentStatus.PAID
+                    payment.order.save(update_fields=['payment_status'])
+                    logger.info(f"{log_prefix} Order {payment.order.order_number} marked as PAID via poll fallback.")
+            elif paynow_status in ('cancelled', 'failed', 'disputed'):
+                payment.status = PaymentStatus.FAILED
+                payment.provider_response = {**(payment.provider_response or {}), 'poll_status': status_response}
+                payment.save(update_fields=['status', 'provider_response', 'updated_at'])
+                logger.info(f"{log_prefix} Payment marked FAILED (Paynow status: '{paynow_status}').")
             else:
-                logger.info(f"{log_prefix} Received non-final IPN status '{paynow_status}'. No action taken, polling will handle it.")
+                # Still pending - back off and retry rather than hammering Paynow.
+                retry_delay = 30 * (2 ** self.request.retries) + random.randint(0, 10)
+                logger.info(f"{log_prefix} Still '{paynow_status}'. Retrying in {retry_delay}s.")
+                raise self.retry(countdown=retry_delay)
 
+        # Send the same WhatsApp confirmation as the IPN handler, but only once
+        # (guarded by the PENDING check above - this task only reaches here on
+        # the transition into a terminal state).
+        if paynow_status == 'paid' and payment.order and payment.customer and payment.customer.contact:
+            _send_payment_confirmation(payment)
+
+    except Payment.DoesNotExist:
+        logger.warning(f"{log_prefix} Payment not found on retry. Stopping.")
+    except self.MaxRetriesExceededError:
+        logger.warning(f"{log_prefix} Max retries exceeded without a final status. Leaving payment PENDING for IPN/manual follow-up.")
+
+
+def _send_payment_confirmation(payment: Payment):
+    """Sends the WhatsApp payment-received message + provisional receipt PDF.
+    Mirrors the notification logic in paynow_integration/views.py's IPN handler."""
+    from django.conf import settings
+    from meta_integration.utils import send_whatsapp_message
+    from customer_data.receipts import generate_order_receipt_pdf
+
+    try:
+        contact = payment.customer.contact
+        confirmation_msg = (
+            f"✅ *Payment Received!*\n\n"
+            f"Thank you! Your payment of ${payment.amount} {payment.currency} for "
+            f"order #{payment.order.order_number} has been confirmed.\n\n"
+            f"We will process your order shortly."
+        )
+        send_whatsapp_message(
+            to_phone_number=contact.whatsapp_id,
+            message_type='text',
+            data={'body': confirmation_msg}
+        )
+
+        try:
+            abs_path, rel_url = generate_order_receipt_pdf(payment.order, payment)
+            backend_domain = getattr(settings, 'BACKEND_DOMAIN_FOR_CSP', None)
+            if backend_domain:
+                absolute_url = f"https://{backend_domain}{rel_url}"
+                send_whatsapp_message(
+                    to_phone_number=contact.whatsapp_id,
+                    message_type='document',
+                    data={
+                        'link': absolute_url,
+                        'caption': f"Provisional Receipt for Order #{payment.order.order_number}"
+                    }
+                )
+        except Exception as rec_e:
+            logger.error(f"Failed to generate/send receipt PDF for payment {payment.id}: {rec_e}")
     except Exception as e:
-        logger.error(f"{log_prefix} An unexpected error occurred while processing the IPN: {e}", exc_info=True)
+        logger.error(f"Failed to send payment confirmation for payment {payment.id}: {e}")

--- a/whatsappcrm_backend/paynow_integration/views.py
+++ b/whatsappcrm_backend/paynow_integration/views.py
@@ -356,6 +356,14 @@ def paynow_ipn_handler(request):
 
             was_already_successful = payment.status == PaymentStatus.SUCCESSFUL
 
+            # SUCCESSFUL is terminal. A later/duplicate IPN reporting a different
+            # status (e.g. 'failed' or 'cancelled') must never demote a payment
+            # that already cleared - that would incorrectly revert a paid order
+            # and is also a plausible spoofing/replay vector.
+            if was_already_successful:
+                logger.info(f"Payment {reference} is already SUCCESSFUL. Ignoring subsequent IPN status update ('{status_val}').")
+                return HttpResponse("OK", status=200)
+
             # Sanity-check the IPN amount against what we actually charged for.
             # A mismatch could indicate a misconfigured/compromised callback and
             # should never silently mark an order as paid.

--- a/whatsappcrm_backend/paynow_integration/views.py
+++ b/whatsappcrm_backend/paynow_integration/views.py
@@ -1,10 +1,12 @@
 # whatsappcrm_backend/paynow_integration/views.py
 
 from rest_framework import viewsets, permissions, status
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view, permission_classes, throttle_classes
 from rest_framework.response import Response
 from rest_framework import serializers
+from rest_framework.throttling import AnonRateThrottle
 from django.views.decorators.csrf import csrf_exempt
+from django.db import transaction
 from django.http import HttpResponse
 from django.urls import reverse
 import logging
@@ -23,6 +25,13 @@ logger = logging.getLogger(__name__)
 
 # URL path constant for IPN callback - used in initiate_whatsapp_payment and paynow_ipn_handler
 PAYNOW_IPN_URL_PATH = '/crm-api/paynow/ipn/'
+
+
+class PaymentInitiationThrottle(AnonRateThrottle):
+    """Throttles the unauthenticated payment-initiation/OTP endpoints, since each
+    call triggers a real mobile-money push (USSD prompt/OTP SMS) to a phone number
+    and could otherwise be abused to spam or rack up gateway costs."""
+    scope = 'payment_initiation'
 
 
 class PaynowConfigViewSet(viewsets.ModelViewSet):
@@ -55,6 +64,7 @@ class PaynowConfigViewSet(viewsets.ModelViewSet):
 
 @api_view(['POST'])
 @permission_classes([permissions.AllowAny])  # Allow anonymous access for WhatsApp flow endpoint
+@throttle_classes([PaymentInitiationThrottle])
 def initiate_whatsapp_payment(request):
     """
     Endpoint to initiate a payment from a WhatsApp flow.
@@ -151,7 +161,16 @@ def initiate_whatsapp_payment(request):
             payment.poll_url = result.get('poll_url')
             payment.provider_response = result
             payment.save(update_fields=['poll_url', 'provider_response'])
-            
+
+            # Schedule a fallback status poll in case Paynow's IPN callback never
+            # arrives (webhooks are inherently unreliable). Delayed so the IPN
+            # gets first chance to confirm the payment without redundant polling.
+            if payment.poll_url:
+                from .tasks import poll_paynow_transaction_status
+                transaction.on_commit(
+                    lambda: poll_paynow_transaction_status.apply_async(args=[str(payment.id)], countdown=90)
+                )
+
             # Update order payment status if order exists
             if order:
                 order.payment_status = Order.PaymentStatus.PENDING
@@ -207,6 +226,7 @@ def initiate_whatsapp_payment(request):
 @csrf_exempt
 @api_view(['POST'])
 @permission_classes([permissions.AllowAny])
+@throttle_classes([PaymentInitiationThrottle])
 def submit_omari_otp(request):
     """
     Submit Omari OTP to complete payment.
@@ -307,14 +327,7 @@ def paynow_ipn_handler(request):
         if not paynow_service.verify_ipn_hash(ipn_data):
             logger.error(f"IPN hash verification failed for reference: {reference}")
             return HttpResponse("Invalid hash", status=403)
-        
-        # Find payment by reference
-        try:
-            payment = Payment.objects.get(provider_transaction_id=reference)
-        except Payment.DoesNotExist:
-            logger.error(f"Payment not found for reference: {reference}")
-            return HttpResponse("Payment not found", status=404)
-        
+
         # Map Paynow status to our status
         status_map = {
             'paid': PaymentStatus.SUCCESSFUL,
@@ -327,24 +340,54 @@ def paynow_ipn_handler(request):
             'sent': PaymentStatus.PENDING,
             'created': PaymentStatus.PENDING
         }
-        
+
         new_status = status_map.get(status_val, PaymentStatus.PENDING)
-        
-        # Update payment
-        payment.status = new_status
-        payment.provider_response = ipn_data
-        if poll_url:
-            payment.poll_url = poll_url
-        payment.save()
-        
-        logger.info(f"Payment {reference} updated to status: {new_status}")
-        
-        # Update order if payment was successful
-        if new_status == PaymentStatus.SUCCESSFUL and payment.order:
-            payment.order.payment_status = Order.PaymentStatus.PAID
-            payment.order.save(update_fields=['payment_status'])
-            logger.info(f"Order {payment.order.order_number} marked as PAID")
-            
+
+        # Find and lock the payment by reference. Paynow retries IPN delivery on
+        # non-200 responses and can send multiple statuses over a transaction's
+        # lifecycle, so this whole block must be atomic + idempotent to avoid
+        # double-processing (duplicate notifications/receipts, lost updates).
+        with transaction.atomic():
+            try:
+                payment = Payment.objects.select_for_update().get(provider_transaction_id=reference)
+            except Payment.DoesNotExist:
+                logger.error(f"Payment not found for reference: {reference}")
+                return HttpResponse("Payment not found", status=404)
+
+            was_already_successful = payment.status == PaymentStatus.SUCCESSFUL
+
+            # Sanity-check the IPN amount against what we actually charged for.
+            # A mismatch could indicate a misconfigured/compromised callback and
+            # should never silently mark an order as paid.
+            if amount:
+                try:
+                    if Decimal(str(amount)) != payment.amount:
+                        logger.error(
+                            f"IPN amount mismatch for reference {reference}: "
+                            f"received {amount}, expected {payment.amount}. Rejecting."
+                        )
+                        return HttpResponse("Amount mismatch", status=400)
+                except InvalidOperation:
+                    logger.warning(f"IPN amount '{amount}' for reference {reference} is not a valid decimal; skipping amount check.")
+
+            # Update payment
+            payment.status = new_status
+            payment.provider_response = ipn_data
+            if poll_url:
+                payment.poll_url = poll_url
+            payment.save(update_fields=['status', 'provider_response', 'poll_url', 'updated_at'])
+
+            logger.info(f"Payment {reference} updated to status: {new_status}")
+
+            # Update order if payment was successful
+            if new_status == PaymentStatus.SUCCESSFUL and payment.order:
+                payment.order.payment_status = Order.PaymentStatus.PAID
+                payment.order.save(update_fields=['payment_status'])
+                logger.info(f"Order {payment.order.order_number} marked as PAID")
+
+        # Notifications are sent outside the DB transaction (network I/O), and only
+        # on the transition into SUCCESSFUL — never re-sent for a duplicate/retried IPN.
+        if new_status == PaymentStatus.SUCCESSFUL and payment.order and not was_already_successful:
             # Send confirmation to customer via WhatsApp
             try:
                 from meta_integration.utils import send_whatsapp_message

--- a/whatsappcrm_backend/products_and_services/views.py
+++ b/whatsappcrm_backend/products_and_services/views.py
@@ -1227,9 +1227,11 @@ class CartViewSet(viewsets.ViewSet):
         Returns: { order_number, amount, currency }
         """
         from django.db import transaction
+        from django.db.models import F
         from decimal import Decimal
         from customer_data.models import Order, OrderItem, CustomerProfile
         from conversations.models import Contact
+        from .models import Product
         import uuid
 
         cart = self._get_or_create_cart(request)
@@ -1311,6 +1313,26 @@ class CartViewSet(viewsets.ViewSet):
 
         try:
             with transaction.atomic():
+                # Re-validate stock at checkout time (not just at add-to-cart time)
+                # and lock the Product rows so two concurrent checkouts of the same
+                # last unit can't both succeed - add-to-cart only checks stock
+                # opportunistically, leaving a TOCTOU gap until now.
+                product_ids = [ci.product_id for ci in cart_items]
+                locked_products = {
+                    p.id: p for p in Product.objects.select_for_update().filter(id__in=product_ids)
+                }
+                insufficient = []
+                for ci in cart_items:
+                    product = locked_products.get(ci.product_id)
+                    if not product or product.stock_quantity < ci.quantity:
+                        available = product.stock_quantity if product else 0
+                        insufficient.append(f"{ci.product.name} (requested {ci.quantity}, available {available})")
+                if insufficient:
+                    return Response(
+                        {'error': f"Insufficient stock: {'; '.join(insufficient)}"},
+                        status=status.HTTP_409_CONFLICT
+                    )
+
                 # Create order with defensive null-safe assigned_agent
                 order_data = {
                     'customer': customer_profile,
@@ -1326,7 +1348,7 @@ class CartViewSet(viewsets.ViewSet):
                 # Only add assigned_agent if the profile has one
                 if hasattr(customer_profile, 'assigned_agent') and customer_profile.assigned_agent:
                     order_data['assigned_agent'] = customer_profile.assigned_agent
-                
+
                 order = Order.objects.create(**order_data)
 
                 order_items_to_create = []
@@ -1341,6 +1363,10 @@ class CartViewSet(viewsets.ViewSet):
                     ))
                 if order_items_to_create:
                     OrderItem.objects.bulk_create(order_items_to_create)
+
+                # Decrement stock now that the order is committed.
+                for ci in cart_items:
+                    Product.objects.filter(pk=ci.product_id).update(stock_quantity=F('stock_quantity') - ci.quantity)
 
                 # Clear the cart
                 cart.items.all().delete()

--- a/whatsappcrm_backend/whatsappcrm_backend/settings.py
+++ b/whatsappcrm_backend/whatsappcrm_backend/settings.py
@@ -212,7 +212,12 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated', # Default to requiring authentication
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 20, 
+    'PAGE_SIZE': 20,
+    'DEFAULT_THROTTLE_RATES': {
+        # Limits abuse of the unauthenticated Paynow payment-initiation endpoint
+        # (each call triggers a real USSD/mobile-money push to a phone number).
+        'payment_initiation': '10/hour',
+    },
 }
 
 # --- Simple JWT Settings ---
@@ -575,6 +580,12 @@ JAZZMIN_UI_TWEAKS = {
 # It's best to set this in your .env file.
 BACKEND_DOMAIN_FOR_CSP = os.getenv('BACKEND_DOMAIN_FOR_CSP', 'backend.hanna.co.zw')
 FRONTEND_DOMAIN_FOR_CSP = os.getenv('FRONTEND_DOMAIN_FOR_CSP', 'dashboard.hanna.co.zw')
+
+# Public base URL of this backend, used to build absolute callback URLs (e.g. the
+# Paynow IPN result_url). Defaults to BACKEND_DOMAIN_FOR_CSP so payment callbacks
+# work out of the box without a separately-maintained env var; override with
+# SITE_URL if the public-facing domain differs from the CSP backend domain.
+SITE_URL = os.getenv('SITE_URL', f'https://{BACKEND_DOMAIN_FOR_CSP}')
 
 # Base directives for production
 connect_src_list = [


### PR DESCRIPTION
## Summary

Full audit of the shop/e-commerce and Paynow payment flow. The headline finding: **Paynow payment confirmation has never worked in production.** `PaynowService.verify_ipn_hash()` called a method (`verify_ipn_hash`) that didn't exist on the SDK wrapper (only `verify_ipn_callback` was defined), so every real Paynow IPN callback was rejected with "Invalid hash" and no order was ever auto-marked paid. The intended Celery fallback poller was dead code written against a completely different `Payment` model schema (leftover from an unrelated project) and was never scheduled anywhere. `SITE_URL` (used to build the IPN `result_url` handed to Paynow) was also never configured outside local docker-compose, so in production Paynow had no valid callback URL to begin with.

Beyond the payment gateway, the order/cart backend had no stock control (stock was checked at add-to-cart time but never decremented, so concurrent orders could oversell indefinitely) and the WhatsApp catalog webhook could create duplicate orders on Meta's webhook retries.

### Payment gateway (`paynow_integration`)
- Fixed the `verify_ipn_hash`/`verify_ipn_callback` method-name mismatch and rebuilt the hash from the full IPN field set (was hardcoded to 4 fields) with a constant-time comparison.
- `SITE_URL` now defaults from the existing `BACKEND_DOMAIN_FOR_CSP` setting instead of a literal `your-domain.com` placeholder.
- IPN handler is now idempotent: locks the `Payment` row, verifies the IPN amount matches what was actually charged, and only sends the WhatsApp confirmation/receipt on the transition into `SUCCESSFUL` (Paynow retries IPN delivery, which previously caused duplicate notifications/receipts).
- Rewrote the Celery poller against the real `Payment`/`Order` schema and wired it in as a fallback (scheduled 90s after payment initiation) in both payment-initiation code paths, so a missed IPN doesn't leave a payment stuck `PENDING` forever.
- `confirm_payment_method_and_initiate` (a flow action) previously just told the customer to "check your phone" without ever calling Paynow — it now actually initiates the charge.
- Added a unique constraint on `Payment.provider_transaction_id` and throttled the unauthenticated payment-initiation/OTP endpoints (each call triggers a real mobile-money push).

### Order/checkout backend
- Stock is now deducted atomically (`select_for_update` + `F()`) in every order-creation path (web storefront checkout, WhatsApp catalog order, AI shopping cart checkout).
- Web storefront checkout re-validates stock at checkout time and rejects with 409 on insufficient stock, closing the add-to-cart→checkout TOCTOU gap.
- Order totals/line items now use the authoritative `Product.price` instead of trusting the price embedded in the WhatsApp catalog webhook payload.
- Order + order-item creation wrapped in `transaction.atomic()` so a partial failure can't leave an `Order` whose total doesn't match its items.
- De-duplicated WhatsApp webhook retries for order messages and flow responses using the existing wamid-based `Message` dedup pattern — both previously reprocessed unconditionally on Meta's retries, risking duplicate orders / double-initiated payments.

### Frontend
- The checkout page advanced straight to "Order Confirmed" on a manual button click without ever checking whether payment actually succeeded. It now polls the existing (previously unused) `/paynow/payment-status/` endpoint and only shows success once the backend confirms payment, with pending/failed/timeout states.
- Fixed Omari OTP submission sending the wrong reference value (`paynow_reference` instead of the internal `payment_reference` the backend looks payments up by), which meant OTP submission could never find the payment record.

## Test plan
- [x] `python manage.py check` — no issues
- [x] Standalone round-trip test of the new IPN hash function (valid hash accepted, tampered amount rejected, missing hash rejected)
- [x] `npx tsc --noEmit` and `npm run build` on the frontend — no type errors, `/shop/checkout` builds cleanly
- [ ] End-to-end test against real Paynow sandbox credentials (needs live config, not available in this environment)
- [ ] Manual QA of the full checkout → payment → confirmation flow in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RE2tzMzD3x11xhZFoY6LjV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Payment checkout now waits for confirmed backend payment status, with live progress updates and retry/later actions.
  * WhatsApp payments can now be confirmed automatically after payment status is verified.
  * Order processing now handles stock updates more reliably and shows shortfall warnings when items are oversold.

* **Bug Fixes**
  * Duplicate webhook deliveries are now ignored to reduce double-processing.
  * Payment notifications are now more consistent, with better handling for failed or delayed confirmations.
  * Payment and order records are now validated more strictly to prevent mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->