### PR TITLE
Fix duplicate-key crash on Product/SerializedItem blank barcode

### DIFF
--- a/whatsappcrm_backend/products_and_services/models.py
+++ b/whatsappcrm_backend/products_and_services/models.py
@@ -131,6 +131,14 @@ class Product(models.Model):
         if not self.sku:
             from .utils import generate_sku
             self.sku = generate_sku(self)
+        # Normalize blank values to NULL for unique fields. Postgres treats ''
+        # as a real, comparable value under a unique constraint (unlike NULL,
+        # which is always distinct), so multiple products left with a blank
+        # barcode/zoho_item_id collide with each other and fail to save.
+        if self.barcode == '':
+            self.barcode = None
+        if self.zoho_item_id == '':
+            self.zoho_item_id = None
         super().save(*args, **kwargs)
 
     class Meta:
@@ -478,6 +486,15 @@ class SerializedItem(models.Model):
 
     def __str__(self):
         return f"{self.product.name} (SN: {self.serial_number})"
+
+    def save(self, *args, **kwargs):
+        # Postgres treats '' as a real, comparable value under a unique
+        # constraint (unlike NULL, which is always distinct), so multiple
+        # items left with a blank barcode collide with each other and fail
+        # to save.
+        if self.barcode == '':
+            self.barcode = None
+        super().save(*args, **kwargs)
 
     class Meta:
         verbose_name = _("Serialized Item")

--- a/whatsappcrm_backend/products_and_services/views.py
+++ b/whatsappcrm_backend/products_and_services/views.py
@@ -799,7 +799,7 @@ class SerializedItemViewSet(viewsets.ModelViewSet):
                         item = SerializedItem.objects.create(
                             product=product,
                             serial_number=serial_number,
-                            barcode=barcode or '',
+                            barcode=barcode or None,
                             status=SerializedItem.Status.IN_STOCK,
                             current_location=SerializedItem.Location.CUSTOMER,
                             location_notes=notes


### PR DESCRIPTION
## Summary

Follow-up fix surfaced by a live production error right after #364 merged:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "products_and_services_product_barcode_key"
DETAIL:  Key (barcode)=() already exists.
```
on `PATCH /crm-api/products/products/36/`.

`Product.barcode`, `Product.zoho_item_id`, and `SerializedItem.barcode` are all declared `unique=True, blank=True, null=True`. Postgres treats an empty string as a real, comparable value under a unique constraint (unlike `NULL`, which is always distinct per row), so once two rows are left with a blank value they collide. Since Django's `.save()` does a full-row `UPDATE`, it re-writes the unchanged blank value every time — so any edit to *either* colliding row throws this `IntegrityError`, even when the edit doesn't touch that field at all. That's exactly what happened on product 36.

- Normalize blank `barcode`/`zoho_item_id` to `None` in `Product.save()` and blank `barcode` to `None` in a new `SerializedItem.save()` override. This also self-heals existing duplicate-blank rows the next time they're saved through the ORM (i.e. this fix alone resolves the crash on product 36 and any other affected row, no manual data migration needed).
- Fixed `products_and_services/views.py` explicitly writing `barcode=barcode or ''` when creating a new `SerializedItem` (was actively re-introducing the same bug for barcode-less serialized items) — changed to `barcode=barcode or None`.

## Test plan
- [x] `python manage.py check` — no issues
- [ ] Manual verification: re-run the PATCH that previously failed on the affected product in staging/production once deployed, confirm it now succeeds and the row's barcode is stored as `NULL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RE2tzMzD3x11xhZFoY6LjV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or blank barcode values so new products and serialized items save more reliably.
  * Reduced the chance of duplicate-value errors when barcode or item ID fields are left empty.
  * New serialized items created through batch entry now store missing barcodes consistently, making later lookups more predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->