### PR TITLE
Fix backend static files: run collectstatic at container startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     #   docker compose exec backend python manage.py migrate
     command: >
       sh -c "python manage.py collectstatic --noinput &&
-             daphne -b 0.0.0.0 -p 8000 whatsappcrm_backend.asgi:application"
+      exec daphne -b 0.0.0.0 -p 8000 whatsappcrm_backend.asgi:application"
     env_file:
       - ./whatsappcrm_backend/.env.prod
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,12 @@ services:
       - ./whatsappcrm_backend:/app
       - staticfiles_volume:/app/staticfiles # Mount the static files volume (used by collectstatic)
       - mediafiles_volume:/app/mediafiles # Mount the media files volume (user uploads)
+    # collectstatic repopulates staticfiles_volume on every start so WhiteNoise
+    # can serve /static/ (nginx proxies those requests to Daphne).
+    # Run migrate manually if needed:
+    #   docker compose exec backend python manage.py migrate
     command: >
-      sh -c "# python manage.py migrate &&
+      sh -c "python manage.py collectstatic --noinput &&
              daphne -b 0.0.0.0 -p 8000 whatsappcrm_backend.asgi:application"
     env_file:
       - ./whatsappcrm_backend/.env.prod

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,5 +15,8 @@ echo "PostgreSQL is ready."
 echo "Applying database migrations..."
 python manage.py migrate
 
+echo "Collecting static files..."
+python manage.py collectstatic --noinput
+
 echo "Starting Daphne server..."
 exec daphne -b 0.0.0.0 -p 8000 whatsappcrm_backend.asgi:application


### PR DESCRIPTION
## Why static files were broken

Three things combined to 404 every `/static/` request on the backend:

1. **`collectstatic` never ran anywhere in the deployment.** It's commented out in `whatsappcrm_backend/Dockerfile`, absent from the compose `command`, and `entrypoint.sh` (which does run migrate) isn't wired into the image (no `ENTRYPOINT` in the Dockerfile).
2. **The `staticfiles_volume` named volume shadows `/app/staticfiles`** inside the backend container, hiding the `staticfiles/` directory committed in the repo. Since nothing ever ran `collectstatic` in the container, the volume stayed empty (or frozen at whatever it held when first created).
3. **Nginx has no `location /static/` block**, so those requests fall through to `location /` and are proxied to Daphne. That makes WhiteNoise the only server for static assets — and WhiteNoise serves from `STATIC_ROOT` (`/app/staticfiles`), which per point 2 was empty. Result: admin/Jazzmin/DRF pages load with no CSS/JS.

## Fix

- Run `python manage.py collectstatic --noinput` before starting Daphne in the backend service's compose `command`. This repopulates the shared volume on every container start, so WhiteNoise always serves current assets (including after image rebuilds/package upgrades).
- Add the same `collectstatic` step to `entrypoint.sh` so the intended boot flow stays consistent if that script gets wired in later.
- `migrate` remains disabled in the compose command (as it was before); a comment documents how to run it manually.

No settings changes were needed — WhiteNoise middleware, `STATIC_URL`, and `STATIC_ROOT` were already configured correctly.

## Testing

- Verified the folded-scalar `command` parses to a valid shell invocation (`collectstatic --noinput && daphne ...`) with a YAML parser.
- `sh -n entrypoint.sh` passes.
- After deploying: `docker compose up -d --build backend`, then confirm `https://backend.hanna.co.zw/static/admin/css/base.css` returns 200 and the Django admin renders styled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaJxFnVUz63gDLTQGxzXgq

---
_Generated by [Claude Code](https://claude.ai/code/session_01XaJxFnVUz63gDLTQGxzXgq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Static assets are now collected automatically when the app starts, helping ensure the latest styles and files are available without manual steps.
  * Startup logging now clearly indicates when static files are being prepared.

* **Bug Fixes**
  * Improved container startup flow so the backend launches more reliably after setup tasks complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->